### PR TITLE
feat: zoom on map on startpage reverted to show the whole country.

### DIFF
--- a/components/Map.tsx
+++ b/components/Map.tsx
@@ -7,10 +7,10 @@ import { useRouter } from 'next/router'
 
 const INITIAL_VIEW_STATE = {
   longitude: 17.062927,
-  latitude: 61,
-  zoom: 4,
+  latitude: 63,
+  zoom: 3.5,
   minZoom: 3,
-  pitch: 30,
+  pitch: 0,
   bearing: 0,
 }
 
@@ -145,7 +145,6 @@ const Map = ({ emissionsLevels, setSelected, children }: Props) => {
         //   inertia: false,
         // }}
         onClick={({ object }) => {
-          console.log('click', object)
           // IDK what the correct type is
           const name = (object as unknown as Emissions)?.name
           if (name) router.push(`/kommun/${replaceLetters(name).toLowerCase()}`)

--- a/components/Municipality.tsx
+++ b/components/Municipality.tsx
@@ -605,7 +605,7 @@ const Municipality = (props: Props) => {
           {step > 2 && (
             <Adjustments>
               <RangeContainer>
-                {mandateChanges.slice(2, 10).map((value, i) => (
+                {mandateChanges.filter(c => c.start >= 2022 && c.end <= 2030).map((value, i) => (
                   <Range key={i}>
                     <Percentage
                     // style={{
@@ -636,11 +636,11 @@ const Municipality = (props: Props) => {
                   Trend: {Math.round(totalTrend / 1000)} kt CO₂
                 </TotalCo2>
                 <TotalCo2 style={{ color: '#6BA292', marginTop: 5 }}>
-                  Parisavtalet: {Math.round(totalBudget / 1000)} kt CO₂
+                  Parisavtalet: {Math.round(municipality.Budget.CO2Equivalent / 1000)} kt CO₂
                 </TotalCo2>
                 <TotalCo2 style={{ color: 'rgb(239, 191, 23)', marginTop: 5 }}>
                   Din plan: {Math.round(userTotal / 1000)} kt CO₂
-                  {userTotal < totalBudget && ' ✅'}
+                  {userTotal < municipality.Budget.CO2Equivalent && ' ✅'}
                 </TotalCo2>
               </Help>
             </Adjustments>


### PR DESCRIPTION
Map shows whole country now:
<img width="846" alt="image" src="https://user-images.githubusercontent.com/395843/159452185-50e961d0-c598-4403-8beb-a925d25ed5e1.png">


Show same figure in score card as in total:
<img width="854" alt="image" src="https://user-images.githubusercontent.com/395843/159451959-504ab13b-5e18-422e-9ef9-1fbb5b98861e.png">

Start sliders on current year instead of 2021 (which can not be changed since it has already happened)
<img width="361" alt="image" src="https://user-images.githubusercontent.com/395843/159452137-60767fb1-4e4c-4dd2-bf68-6d113ebb7214.png">

