### PR TITLE
Coat of arms alt-text

### DIFF
--- a/components/Municipality.tsx
+++ b/components/Municipality.tsx
@@ -542,7 +542,7 @@ const Municipality = (props: Props) => {
           <HeaderSection>
             <H1>{municipality.Name}</H1>
 
-            {coatOfArmsImage && <CoatOfArmsImage src={coatOfArmsImage} alt="img" />}
+            {coatOfArmsImage && <CoatOfArmsImage src={coatOfArmsImage} alt={`Kommunvapen för ${municipality.Name}`} />}
           </HeaderSection>
           <GraphWrapper>
             <h3>{text}</h3>


### PR DESCRIPTION
It does not describe the visual aspects of the image but might still be an improvement over "img".

An option might be to hide the image with `aria-hidden="true"` as the image is mainly decorative.