### PR TITLE
fix wwf link + CO2 budget copy

### DIFF
--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -241,7 +241,7 @@ const Footer = () => {
                 </Paragraph>
                 <Paragraph>
                   Läs mer om Parisavtalet hos vår samarbetspartner{' '}
-                  <a href="https://wwf.se/klimat" target="_blank" rel="noreferrer">
+                  <a href="https://www.wwf.se/rapport/ipcc/#parisavtalet" target="_blank" rel="noreferrer">
                     WWF
                   </a>
                   .
@@ -291,9 +291,9 @@ const Footer = () => {
                   medräknade i Klimatkollens koldioxidbudget.
                 </Paragraph>
                 <Paragraph>
-                  Den nationella koldioxidbudgeten beräknas av Uppsala Universitet enligt
-                  Tyndall-modellen och fördelas sedan ut på kommunerna av ClimateView. Läs
-                  mer om hur koldioxidbudgeten är beräknad{' '}
+                  Den nationella koldioxidbudgeten beräknas av Uppsala Universitet med grund i den så 
+                  kallade Tyndall-modellen och fördelas sedan ut på kommunerna av ClimateView. 
+                  Läs mer om hur koldioxidbudgeten är beräknad{' '}
                   <a
                     href="/Paris_compliant_Swedish_CO2_budgets-March_2022-Stoddard&Anderson.pdf"
                     target="_blank"


### PR DESCRIPTION
bytte länk till wwf:s parisavtalalssida + ändrade copy ang hur koldioxidbudgeten beräknas 