### PR TITLE
Quick-fix: add tag that went missing on latest Map merge-conflict

### DIFF
--- a/components/Map.tsx
+++ b/components/Map.tsx
@@ -164,6 +164,7 @@ const Map = ({ emissionsLevels, setSelected, children }: Props) => {
           viewState.latitude = Math.min(MAP_RANGE.lat[1], Math.max(MAP_RANGE.lat[0], viewState.latitude))
           return viewState
         }}
+      />
       {children}
     </DeckGLWrapper>
   )


### PR DESCRIPTION
La till klammer som försvann i senaste merge-konflikten på Maps!