### PR TITLE
remove viewstate constraints bc not mobile friendly atm

### DIFF
--- a/components/Map.tsx
+++ b/components/Map.tsx
@@ -159,11 +159,13 @@ const Map = ({ emissionsLevels, setSelected, children }: Props) => {
           if (name) router.push(`/kommun/${replaceLetters(name).toLowerCase()}`)
         }}
         layers={[kommunLayer]}
-        onViewStateChange={({ viewState }) => {
+        // FIXME needs to be adapted to mobile before reintroducing
+        /*onViewStateChange={({ viewState }) => {
           viewState.longitude = Math.min(MAP_RANGE.lon[1], Math.max(MAP_RANGE.lon[0], viewState.longitude))
           viewState.latitude = Math.min(MAP_RANGE.lat[1], Math.max(MAP_RANGE.lat[0], viewState.latitude))
           return viewState
-        }}
+        }}*/
+      />
       {children}
     </DeckGLWrapper>
   )


### PR DESCRIPTION
Ny vända med begränsningar i kartan. Nu tagit bort dem igen pga funkar inte på mobilen, måste hitta sätt så att det blir bra både på desktop och mobil.