### PR TITLE
Inject NEXT_PUBLIC_MAILCHIMP_URL with dummy value in dev script.

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "klimatkollen",
   "private": true,
   "scripts": {
-    "dev": "next dev",
+    "dev": "NEXT_PUBLIC_MAILCHIMP_URL=https:// next dev",
     "build": "next build",
     "start": "next start",
     "lint": "next lint",


### PR DESCRIPTION
### WHAT
Setting NEXT_PUBLIC_MAILCHIMP_URL to dummy url when running dev script

### WHY
The instructions claim that 

$ yarn
$ yarn dev

is all that is required to start the project locally. Not so, because NEXT_PUBLIC_MAILCHIMP_URL is required.

