### PR TITLE
Make map zoomable on desktop

### DIFF
--- a/components/Map.tsx
+++ b/components/Map.tsx
@@ -142,7 +142,10 @@ const Map = ({ emissionsLevels, setSelected, children }: Props) => {
         // touchAction="unset"
         initialViewState={INITIAL_VIEW_STATE}
         controller={{
-          scrollZoom: false
+          // Removed this to make desktop map zoomable
+          // Wonder why it was set to false in first place tho
+          // could be that it has to be reversed
+          // scrollZoom: false
         }}
         getTooltip={({ object }) => object && {
           html: `<p>${(object as unknown as Emissions)?.name}</p>`,


### PR DESCRIPTION
För att fix #92 
Har provat på desktop och iPhone och funkar fint för mig. 

Förstår dock inte varför det explicit skrivits att det inte ska gå att zooma innan så undrar om det kan finnas ngn anledning till det. Får gärna testas av ngn annan också innan merge.