### PR TITLE
Improve the existing municipality search – sorting by Swedish and prioritizing matches that begin with the input query

### DIFF
--- a/components/DropDown.test.ts
+++ b/components/DropDown.test.ts
@@ -2,7 +2,9 @@ import { test } from 'vitest'
 import { getSortedMunicipalities, search } from './DropDown'
 
 test('Municipalities should be sorted by Swedish alphabetical order', () => {
-  expect(getSortedMunicipalities(['Örebro', 'Säffle', 'Älmhult', 'Åre', 'Karlshamn'])).toEqual(['Karlshamn', 'Säffle', 'Åre', 'Älmhult', 'Örebro'])
+  expect(
+    getSortedMunicipalities(['Örebro', 'Säffle', 'Älmhult', 'Åre', 'Karlshamn']),
+  ).toEqual(['Karlshamn', 'Säffle', 'Åre', 'Älmhult', 'Örebro'])
 })
 
 describe('When searching a list of sorted municipalities', () => {
@@ -19,6 +21,10 @@ describe('When searching a list of sorted municipalities', () => {
   })
 
   test('Results that start with the query should be prioritized', () => {
-    expect(search('st', ['Avesta', 'Mariestad', 'Stockholm'])).toEqual(['Stockholm', 'Avesta', 'Mariestad'])
+    expect(search('st', ['Avesta', 'Mariestad', 'Stockholm'])).toEqual([
+      'Stockholm',
+      'Avesta',
+      'Mariestad',
+    ])
   })
 })

--- a/components/DropDown.test.ts
+++ b/components/DropDown.test.ts
@@ -1,0 +1,24 @@
+import { test } from 'vitest'
+import { getSortedMunicipalities, search } from './DropDown'
+
+test('Municipalities should be sorted by Swedish alphabetical order', () => {
+  expect(getSortedMunicipalities(['Örebro', 'Säffle', 'Älmhult', 'Åre', 'Karlshamn'])).toEqual(['Karlshamn', 'Säffle', 'Åre', 'Älmhult', 'Örebro'])
+})
+
+describe('When searching a list of sorted municipalities', () => {
+  const municipalities = ['Göteborg', 'Malmö', 'Stockholm', 'Södertälje']
+
+  test('Results that do not include the query should be filtered out', () => {
+    expect(search('holm', municipalities)).toEqual(['Stockholm'])
+    expect(search('s', municipalities)).toEqual(['Stockholm', 'Södertälje'])
+  })
+
+  test('The search is case-insensitive', () => {
+    expect(search('göt', municipalities)).toEqual(['Göteborg'])
+    expect(search('GÖt', municipalities)).toEqual(['Göteborg'])
+  })
+
+  test('Results that start with the query should be prioritized', () => {
+    expect(search('st', ['Avesta', 'Mariestad', 'Stockholm'])).toEqual(['Stockholm', 'Avesta', 'Mariestad'])
+  })
+})

--- a/components/DropDown.tsx
+++ b/components/DropDown.tsx
@@ -5,79 +5,79 @@ import ArrowDown from '../public/icons/arrow-down.svg'
 import { devices } from '../utils/devices'
 
 const Container = styled.div`
-  display: flex;
-  flex-direction: row;
-  align-items: center;
-  gap: 1rem;
-  width: 100%;
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    gap: 1rem;
+    width: 100%;
 
-  @media only screen and (${devices.tablet}) {
-    width: 325px;
-  }
+    @media only screen and (${devices.tablet}) {
+        width: 325px;
+    }
 `
 
 const SearchDropDown = styled.div`
-  position: relative;
-  width: 100%;
+    position: relative;
+    width: 100%;
 `
 
 const Flex = styled.div`
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  width: 100%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 100%;
 `
 
 const StyledInput = styled.input`
-  width: 100%;
-  height: 56px;
-  background-color: transparent;
-  border: 1px solid ${({ theme }) => theme.midGreen};
-  border-radius: 4px;
-  color: ${({ theme }) => theme.offWhite};
-  font-size: 16px;
-  font-weight: 300;
-  font-family: Borna;
-  padding-left: 0.8rem;
-  outline: none;
-  width: 325px;
-
-  ::placeholder {
+    width: 100%;
+    height: 56px;
+    background-color: transparent;
+    border: 1px solid ${({ theme }) => theme.midGreen};
+    border-radius: 4px;
     color: ${({ theme }) => theme.offWhite};
-  }
+    font-size: 16px;
+    font-weight: 300;
+    font-family: Borna;
+    padding-left: 0.8rem;
+    outline: none;
+    width: 325px;
+
+    ::placeholder {
+        color: ${({ theme }) => theme.offWhite};
+    }
 `
 
 const Btn = styled.button`
-  background-color: transparent;
-  width: 20px;
-  height: 20px;
-  right: 16px;
-  position: absolute;
-  border: none;
+    background-color: transparent;
+    width: 20px;
+    height: 20px;
+    right: 16px;
+    position: absolute;
+    border: none;
 `
 
 const MunicipalitiesWrapper = styled.ul`
-  background-color: ${({ theme }) => theme.lightBlack};
-  border-radius: 4px;
-  max-height: 195px;
-  overflow-y: scroll;
-  position: absolute;
-  z-index: 20;
+    background-color: ${({ theme }) => theme.lightBlack};
+    border-radius: 4px;
+    max-height: 195px;
+    overflow-y: scroll;
+    position: absolute;
+    z-index: 20;
 `
 
 const Municipality = styled.li`
-  color: ${({ theme }) => theme.offWhite};
-  text-decoration: none;
-  width: 310px;
-  height: 56px;
-  display: flex;
-  align-items: center;
-  padding-left: 1rem;
-  position: relative;
+    color: ${({ theme }) => theme.offWhite};
+    text-decoration: none;
+    width: 310px;
+    height: 56px;
+    display: flex;
+    align-items: center;
+    padding-left: 1rem;
+    position: relative;
 `
 
 const ErrorText = styled.div`
-  margin-top: 8px;
+    margin-top: 8px;
 `
 
 type Props = {
@@ -86,8 +86,34 @@ type Props = {
   className: string
 }
 
+export function getSortedMunicipalities(municipalitiesName: Array<string>) {
+  return municipalitiesName.sort((a, b) => a.localeCompare(b, 'sv'))
+}
+
+export function search(query: string, municipalitiesName: Array<string>) {
+  const queryLowerCase = query.toLowerCase()
+
+  return municipalitiesName
+    .filter((municipality) => municipality.toLowerCase().includes(queryLowerCase))
+    .sort((a, b) => {
+      const lowerA = a.toLowerCase()
+      const lowerB = b.toLowerCase()
+
+      const startsWithQueryA = lowerA.startsWith(queryLowerCase)
+      const startsWithQueryB = lowerB.startsWith(queryLowerCase)
+
+      if (startsWithQueryA && !startsWithQueryB) {
+        return -1
+      } if (!startsWithQueryA && startsWithQueryB) {
+        return 1
+      }
+
+      return 0
+    })
+}
+
 function DropDown({ municipalitiesName, placeholder, className }: Props) {
-  const sortedMunicipalities = municipalitiesName.sort((a, b) => a.localeCompare(b))
+  const sortedMunicipalities = getSortedMunicipalities(municipalitiesName)
   const [showDropDown, setShowDropDown] = useState(false)
   const [selectedMunicipality, setSelectedMunicipality] = useState<string>('')
   const [municipalities, setMunicipalities] = useState(sortedMunicipalities)
@@ -128,7 +154,7 @@ function DropDown({ municipalitiesName, placeholder, className }: Props) {
     } else {
       setShowDropDown(true)
     }
-    const filteredMunicipalities = sortedMunicipalities.filter((test) => test.toLowerCase().includes(value.toLowerCase()))
+    const filteredMunicipalities = search(value, sortedMunicipalities)
     setMunicipalities(filteredMunicipalities)
   }
 

--- a/components/DropDown.tsx
+++ b/components/DropDown.tsx
@@ -5,79 +5,79 @@ import ArrowDown from '../public/icons/arrow-down.svg'
 import { devices } from '../utils/devices'
 
 const Container = styled.div`
-    display: flex;
-    flex-direction: row;
-    align-items: center;
-    gap: 1rem;
-    width: 100%;
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  gap: 1rem;
+  width: 100%;
 
-    @media only screen and (${devices.tablet}) {
-        width: 325px;
-    }
+  @media only screen and (${devices.tablet}) {
+    width: 325px;
+  }
 `
 
 const SearchDropDown = styled.div`
-    position: relative;
-    width: 100%;
+  position: relative;
+  width: 100%;
 `
 
 const Flex = styled.div`
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
 `
 
 const StyledInput = styled.input`
-    width: 100%;
-    height: 56px;
-    background-color: transparent;
-    border: 1px solid ${({ theme }) => theme.midGreen};
-    border-radius: 4px;
-    color: ${({ theme }) => theme.offWhite};
-    font-size: 16px;
-    font-weight: 300;
-    font-family: Borna;
-    padding-left: 0.8rem;
-    outline: none;
-    width: 325px;
+  width: 100%;
+  height: 56px;
+  background-color: transparent;
+  border: 1px solid ${({ theme }) => theme.midGreen};
+  border-radius: 4px;
+  color: ${({ theme }) => theme.offWhite};
+  font-size: 16px;
+  font-weight: 300;
+  font-family: Borna;
+  padding-left: 0.8rem;
+  outline: none;
+  width: 325px;
 
-    ::placeholder {
-        color: ${({ theme }) => theme.offWhite};
-    }
+  ::placeholder {
+    color: ${({ theme }) => theme.offWhite};
+  }
 `
 
 const Btn = styled.button`
-    background-color: transparent;
-    width: 20px;
-    height: 20px;
-    right: 16px;
-    position: absolute;
-    border: none;
+  background-color: transparent;
+  width: 20px;
+  height: 20px;
+  right: 16px;
+  position: absolute;
+  border: none;
 `
 
 const MunicipalitiesWrapper = styled.ul`
-    background-color: ${({ theme }) => theme.lightBlack};
-    border-radius: 4px;
-    max-height: 195px;
-    overflow-y: scroll;
-    position: absolute;
-    z-index: 20;
+  background-color: ${({ theme }) => theme.lightBlack};
+  border-radius: 4px;
+  max-height: 195px;
+  overflow-y: scroll;
+  position: absolute;
+  z-index: 20;
 `
 
 const Municipality = styled.li`
-    color: ${({ theme }) => theme.offWhite};
-    text-decoration: none;
-    width: 310px;
-    height: 56px;
-    display: flex;
-    align-items: center;
-    padding-left: 1rem;
-    position: relative;
+  color: ${({ theme }) => theme.offWhite};
+  text-decoration: none;
+  width: 310px;
+  height: 56px;
+  display: flex;
+  align-items: center;
+  padding-left: 1rem;
+  position: relative;
 `
 
 const ErrorText = styled.div`
-    margin-top: 8px;
+  margin-top: 8px;
 `
 
 type Props = {
@@ -104,7 +104,8 @@ export function search(query: string, municipalitiesName: Array<string>) {
 
       if (startsWithQueryA && !startsWithQueryB) {
         return -1
-      } if (!startsWithQueryA && startsWithQueryB) {
+      }
+      if (!startsWithQueryA && startsWithQueryB) {
         return 1
       }
 


### PR DESCRIPTION
When I started searching for Stockholm, I noticed that the municipality typeahead/autocomplete dropdown behaved in a really weird way:

<img width="895" alt="image" src="https://github.com/Klimatbyran/klimatkollen/assets/6412575/97b076ee-3b7b-4be8-98a1-346f15f6dbb5">

As a user, I'd prefer if results that start with my search query are ranked higher.

This PR improves two things:
- Municipalities are now properly sorted before they're fed into the search. If no locales are explicitly passed to localeCompare(), it defaults to the user's locale. My machine and browser are both in English, so the sorting got whacky. I think an explicit `'sv'` would be better, since we're dealing with Swedish municipalities.
- The search filter is now smarter, taking into consideration results that start with the query.

With the fix:

<img width="920" alt="image" src="https://github.com/Klimatbyran/klimatkollen/assets/6412575/0e0f06cb-05ce-424f-b116-2ba36263c2a9">
