### PR TITLE
Fix 370 Animate Paris Agreement graph

### DIFF
--- a/components/Graph.tsx
+++ b/components/Graph.tsx
@@ -118,7 +118,7 @@ function Graph({
               // @ts-ignore
               id: 'budget',
               fill: true,
-              data: step >= 2 ? budgetDataset : budgetDataset.map(({x}) => ({x, y:0})),
+              data: step >= 2 ? budgetDataset : budgetDataset.map(({ x }) => ({ x, y: 0 })),
               borderWidth: step >= 2 ? 2 : 0,
               borderColor: colorTheme.lightGreen,
               backgroundColor: colorTheme.lightGreenOpaqe,

--- a/components/Graph.tsx
+++ b/components/Graph.tsx
@@ -118,13 +118,13 @@ function Graph({
               // @ts-ignore
               id: 'budget',
               fill: true,
-              data: budgetDataset,
-              borderWidth: 2,
+              data: step >= 2 ? budgetDataset : budgetDataset.map(({x}) => ({x, y:0})),
+              borderWidth: step >= 2 ? 2 : 0,
               borderColor: colorTheme.lightGreen,
               backgroundColor: colorTheme.lightGreenOpaqe,
               pointRadius: 0,
               tension: 0.15,
-              hidden: step < 2,
+              hidden: false,
             },
             {
               // @ts-ignore


### PR DESCRIPTION
Solves  #370.

It seems the "default" animations of chart.js only work if the dataset is visible at all times, although we can visually hide it, as done in this PR. It feels a bit sketchy, but its the quickest way to fix the issue.