### PR TITLE
Decrease map/list title size for mobile screens

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -71,6 +71,7 @@ const TitleContainer = styled.div`
 
 const FloatingH5 = styled.h5`
   position: absolute;
+  font-size: 16px;
   font-weight: regular;
   line-height: 1.25;
   margin: 55px 0 0 16px;

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -6,7 +6,7 @@ import styled from 'styled-components'
 import { useRouter } from 'next/router'
 import DropDown from '../components/DropDown'
 import MetaTags from '../components/MetaTags'
-import { H2Regular, H5Regular, Paragraph } from '../components/Typography'
+import { H2Regular, Paragraph } from '../components/Typography'
 import { Municipality, SelectedData } from '../utils/types'
 import PageWrapper from '../components/PageWrapper'
 import { devices } from '../utils/devices'
@@ -69,13 +69,17 @@ const TitleContainer = styled.div`
   align-items: center;
 `
 
-const FloatingH5 = styled(H5Regular)`
+const FloatingH5 = styled.h5`
   position: absolute;
-  margin: 60px 0 0 16px;
+  font-weight: regular;
+  line-height: 1.25;
+  margin: 55px 0 0 16px;
   z-index: 200;
 
-  @media only screen and (${devices.mobile}) {
-    margin: 55px 0 0 16px;
+  @media only screen and (${devices.tablet}) {
+    font-size: 18px;
+    margin: 60px 0 0 16px;
+    font-size
   }
 `
 


### PR DESCRIPTION
Decrease map/list title size for mobile screens. From

<img width="590" alt="Screenshot 2024-03-26 at 20 49 26" src="https://github.com/Klimatbyran/klimatkollen/assets/7899748/baf9b2cf-9eaf-49bb-b2fd-a16711d98931">

to

<img width="541" alt="Screenshot 2024-03-26 at 20 49 40" src="https://github.com/Klimatbyran/klimatkollen/assets/7899748/2f451814-ddd4-4b7e-ae46-41792e8f0f91">

Fix #439 