### PR TITLE
Feature/klimatkollen add sorting to binary data

### DIFF
--- a/components/ComparisonTable.tsx
+++ b/components/ComparisonTable.tsx
@@ -102,6 +102,7 @@ function ComparisonTable<T extends object>({ data, columns }: TableProps<T>) {
     columns,
     state: { sorting },
     enableSortingRemoval: false,
+    isMultiSortEvent: (e) => true,
     onSortingChange: setSorting,
     getCoreRowModel: getCoreRowModel(),
     getSortedRowModel: getSortedRowModel(),

--- a/components/ComparisonTable.tsx
+++ b/components/ComparisonTable.tsx
@@ -80,7 +80,7 @@ type TableProps<T extends object> = {
 }
 
 function ComparisonTable<T extends object>({ data, columns }: TableProps<T>) {
-  const [sorting, setSorting] = useState<SortingState>([])
+  const [sorting, setSorting] = useState<SortingState>([{id: 'index', desc: false}, {id: 'name', desc: false}])
   const router = useRouter()
 
   const [resizeCount, setResizeCount] = useState(0)
@@ -101,6 +101,7 @@ function ComparisonTable<T extends object>({ data, columns }: TableProps<T>) {
     data,
     columns,
     state: { sorting },
+    enableSortingRemoval: false,
     onSortingChange: setSorting,
     getCoreRowModel: getCoreRowModel(),
     getSortedRowModel: getSortedRowModel(),

--- a/components/ComparisonTable.tsx
+++ b/components/ComparisonTable.tsx
@@ -145,11 +145,13 @@ function ComparisonTable<T extends object>({ data, columns }: TableProps<T>) {
 
   return (
     <StyledTable key={resizeCount}>
+      <thead>
       {table.getHeaderGroups().map((headerGroup) => (
         <tr key={headerGroup.id}>
           {headerGroup.headers.map((header, index) => renderHeader(header, index))}
         </tr>
       ))}
+      </thead>
       <tbody>
         {table.getRowModel().rows.map((row) => (
           <TableRow key={row.id} onClick={() => handleRowClick(row)}>


### PR DESCRIPTION
Related to: https://github.com/Klimatbyran/klimatkollen/issues/351

This PR modifies the code so that the sorting is based on municipality: i.e. if the user sorts for "has action plan", the answer "yes/no" is still alphabetically sorted. The PR also initialises the column data in alphabetical order for the municipalities based on which municipalities currently have an action plan.

<img width="653" alt="image" src="https://github.com/Klimatbyran/klimatkollen/assets/38570172/c7f91064-1146-411d-9f19-07500be63bdf">
<img width="632" alt="image" src="https://github.com/Klimatbyran/klimatkollen/assets/38570172/3c7e6140-fe4e-44ac-9bff-f44f98291824">
