### PR TITLE
Update to latest deck.gl, removing vulnerabilities Fixes #324

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "axios": "^1.6.7",
         "babel-plugin-styled-components": "^2.1.4",
         "chart.js": "^4.4.1",
-        "deck.gl": "8.6.6",
+        "deck.gl": "^9.0.6",
         "jsdom": "^24.0.0",
         "md5": "^2.3.0",
         "next": "14.1.0",
@@ -1894,6 +1894,7 @@
       "version": "7.15.4",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.15.4.tgz",
       "integrity": "sha512-99catp6bHCaxr4sJ/DbTGgHS4+Rs2RVd2g7iOap6SLGPDknRK9ztKNsE/Fg6QhSeh1FGE5f6gHGQmvvn3I3xhw==",
+      "dev": true,
       "dependencies": {
         "regenerator-runtime": "^0.13.4"
       },
@@ -1980,158 +1981,220 @@
       }
     },
     "node_modules/@deck.gl/aggregation-layers": {
-      "version": "8.6.6",
-      "resolved": "https://registry.npmjs.org/@deck.gl/aggregation-layers/-/aggregation-layers-8.6.6.tgz",
-      "integrity": "sha512-+G9iapAqFPE/MbTjkX3NnkeEYIOFY+eQFqO2pOqJlSWDIXT5eNQV5tZTMB5SN8fMVCYrfZ4RhxrYsO3kltWtIQ==",
+      "version": "9.0.6",
+      "resolved": "https://registry.npmjs.org/@deck.gl/aggregation-layers/-/aggregation-layers-9.0.6.tgz",
+      "integrity": "sha512-MYOg005XLMHA2pYCvI+6KSAxyFiCS/M5FRkOITDkzhZsRsBY2nsb38lXgX+fDupn8JiYFz6nj37GVpudapxa2g==",
       "dependencies": {
-        "@luma.gl/shadertools": "^8.5.10",
-        "@math.gl/web-mercator": "^3.5.4",
+        "@luma.gl/constants": "^9.0.9",
+        "@luma.gl/shadertools": "^9.0.9",
+        "@math.gl/web-mercator": "^4.0.0",
         "d3-hexbin": "^0.2.1"
       },
       "peerDependencies": {
-        "@deck.gl/core": "^8.0.0",
-        "@deck.gl/layers": "^8.0.0"
+        "@deck.gl/core": "^9.0.0",
+        "@deck.gl/layers": "^9.0.0",
+        "@luma.gl/core": "^9.0.0",
+        "@luma.gl/engine": "^9.0.0"
       }
     },
     "node_modules/@deck.gl/carto": {
-      "version": "8.6.6",
-      "resolved": "https://registry.npmjs.org/@deck.gl/carto/-/carto-8.6.6.tgz",
-      "integrity": "sha512-JUpCusUBuL4K1zC1ZvNfkRd6ShnmZwy2QhlwHy2+x5OsPB63bEg9P8lG/PGfj9JIYFgX8lBdfDX0AHO4oSgzVQ==",
+      "version": "9.0.6",
+      "resolved": "https://registry.npmjs.org/@deck.gl/carto/-/carto-9.0.6.tgz",
+      "integrity": "sha512-+sKoz75AwS58LJ64QRov4ZDHQMqJ/8aIYQ9cfb4Yo+lkje8ihUK0xeVEBLnYZPsbGYBRV//qXTuyPp6rxjWjbA==",
       "dependencies": {
-        "@loaders.gl/loader-utils": "^3.1.5",
-        "@loaders.gl/mvt": "^3.1.5",
-        "@loaders.gl/tiles": "^3.1.5",
-        "@math.gl/web-mercator": "^3.5.6",
+        "@loaders.gl/gis": "^4.1.4",
+        "@loaders.gl/loader-utils": "^4.1.4",
+        "@loaders.gl/mvt": "^4.1.4",
+        "@loaders.gl/schema": "^4.1.4",
+        "@loaders.gl/tiles": "^4.1.4",
+        "@luma.gl/constants": "^9.0.9",
+        "@math.gl/web-mercator": "^4.0.0",
+        "@types/d3-array": "^3.0.2",
+        "@types/d3-color": "^1.4.2",
+        "@types/d3-scale": "^3.0.0",
         "cartocolor": "^4.0.2",
-        "d3-scale": "^3.2.3"
+        "d3-array": "^3.2.0",
+        "d3-color": "^3.1.0",
+        "d3-format": "^3.1.0",
+        "d3-scale": "^4.0.0",
+        "earcut": "^2.2.4",
+        "h3-js": "^4.1.0",
+        "moment-timezone": "^0.5.33",
+        "pbf": "^3.2.1",
+        "quadbin": "^0.2.0"
       },
       "peerDependencies": {
-        "@deck.gl/core": "^8.0.0",
-        "@deck.gl/geo-layers": "^8.0.0",
-        "@deck.gl/layers": "^8.0.0",
-        "@loaders.gl/core": "^3.1.5"
+        "@deck.gl/aggregation-layers": "^9.0.0",
+        "@deck.gl/core": "^9.0.0",
+        "@deck.gl/extensions": "^9.0.0",
+        "@deck.gl/geo-layers": "^9.0.0",
+        "@deck.gl/layers": "^9.0.0",
+        "@loaders.gl/core": "^4.1.0",
+        "@luma.gl/core": "^9.0.0"
       }
     },
     "node_modules/@deck.gl/core": {
-      "version": "8.6.6",
-      "resolved": "https://registry.npmjs.org/@deck.gl/core/-/core-8.6.6.tgz",
-      "integrity": "sha512-dCQxKkOT3mOA6RY6+iUTIyW4II04YiZ49uM/0+Un8KXzSzwhwDBQB2vpyKoMUhdjyvEB/64lnr2XQHU0wg1K8A==",
+      "version": "9.0.6",
+      "resolved": "https://registry.npmjs.org/@deck.gl/core/-/core-9.0.6.tgz",
+      "integrity": "sha512-fVuAG7LfEjhSLbxzovGzQ6q6ARmLKooEJtMORWOOQE3TvI3Yt9PnRNlldLzdD5xXFcG5QSdiNH7C1Y7xnoh2EA==",
       "dependencies": {
-        "@loaders.gl/core": "^3.1.5",
-        "@loaders.gl/images": "^3.1.5",
-        "@luma.gl/core": "^8.5.10",
-        "@math.gl/web-mercator": "^3.5.6",
+        "@loaders.gl/core": "^4.1.4",
+        "@loaders.gl/images": "^4.1.4",
+        "@luma.gl/constants": "^9.0.9",
+        "@luma.gl/core": "^9.0.9",
+        "@luma.gl/engine": "^9.0.9",
+        "@luma.gl/shadertools": "^9.0.9",
+        "@luma.gl/webgl": "^9.0.9",
+        "@math.gl/core": "^4.0.0",
+        "@math.gl/sun": "^4.0.0",
+        "@math.gl/web-mercator": "^4.0.0",
+        "@probe.gl/env": "^4.0.9",
+        "@probe.gl/log": "^4.0.9",
+        "@probe.gl/stats": "^4.0.9",
+        "@types/offscreencanvas": "^2019.6.4",
         "gl-matrix": "^3.0.0",
-        "math.gl": "^3.5.4",
-        "mjolnir.js": "^2.5.0",
-        "probe.gl": "^3.4.0"
+        "mjolnir.js": "^2.7.0"
       }
     },
     "node_modules/@deck.gl/extensions": {
-      "version": "8.6.6",
-      "resolved": "https://registry.npmjs.org/@deck.gl/extensions/-/extensions-8.6.6.tgz",
-      "integrity": "sha512-BCDBEtaXV2Fi/o8Mn71WJYV6Vn+iKSuzeutNsPipyckT/aKJOUZ47gVomYaAgpQe2LyP3B9JewJYWOX+k3IRWg==",
+      "version": "9.0.6",
+      "resolved": "https://registry.npmjs.org/@deck.gl/extensions/-/extensions-9.0.6.tgz",
+      "integrity": "sha512-3V+TdjahbU7+dltsDTnFpn6v3NjG4In77F4Jwio9fXCFfXwpwij98tmCq6TAGS9Xgp0Aj04BFnriAnO/Cddv4w==",
       "dependencies": {
-        "@luma.gl/shadertools": "^8.5.10"
+        "@luma.gl/constants": "^9.0.9",
+        "@luma.gl/shadertools": "^9.0.9",
+        "@math.gl/core": "^4.0.0"
       },
       "peerDependencies": {
-        "@deck.gl/core": "^8.0.0",
-        "gl-matrix": "^3.0.0"
+        "@deck.gl/core": "^9.0.0",
+        "@luma.gl/core": "^9.0.0",
+        "@luma.gl/engine": "^9.0.0"
       }
     },
     "node_modules/@deck.gl/geo-layers": {
-      "version": "8.6.6",
-      "resolved": "https://registry.npmjs.org/@deck.gl/geo-layers/-/geo-layers-8.6.6.tgz",
-      "integrity": "sha512-Ob/7xzeTbM/qhW20trE4UOF8DtJ2eIvr+Jtwt2D5Xre947aPXRgdqtd3WBmaZEVNlzLGZBZHbuJcYfIXyP7dow==",
+      "version": "9.0.6",
+      "resolved": "https://registry.npmjs.org/@deck.gl/geo-layers/-/geo-layers-9.0.6.tgz",
+      "integrity": "sha512-O6s7w77M9sSJ8/+M0e/kLUr9u1TVNDJMqHGECrY99fVbVfTZSQbSoMVA7DMmfw+/aaa4g4emcJoRkHMf96BMHg==",
       "dependencies": {
-        "@loaders.gl/3d-tiles": "^3.1.5",
-        "@loaders.gl/gis": "^3.1.5",
-        "@loaders.gl/loader-utils": "^3.1.5",
-        "@loaders.gl/mvt": "^3.1.5",
-        "@loaders.gl/terrain": "^3.1.5",
-        "@loaders.gl/tiles": "^3.1.5",
-        "@luma.gl/experimental": "^8.5.10",
-        "@math.gl/culling": "^3.5.6",
-        "@math.gl/web-mercator": "^3.5.6",
-        "h3-js": "^3.6.0",
-        "long": "^3.2.0",
-        "math.gl": "^3.5.6"
+        "@loaders.gl/3d-tiles": "^4.1.4",
+        "@loaders.gl/gis": "^4.1.4",
+        "@loaders.gl/loader-utils": "^4.1.4",
+        "@loaders.gl/mvt": "^4.1.4",
+        "@loaders.gl/schema": "^4.1.4",
+        "@loaders.gl/terrain": "^4.1.4",
+        "@loaders.gl/tiles": "^4.1.4",
+        "@loaders.gl/wms": "^4.1.4",
+        "@luma.gl/gltf": "^9.0.9",
+        "@luma.gl/shadertools": "^9.0.9",
+        "@math.gl/core": "^4.0.0",
+        "@math.gl/culling": "^4.0.0",
+        "@math.gl/web-mercator": "^4.0.0",
+        "@types/geojson": "^7946.0.8",
+        "h3-js": "^4.1.0",
+        "long": "^3.2.0"
       },
       "peerDependencies": {
-        "@deck.gl/core": "^8.0.0",
-        "@deck.gl/extensions": "^8.0.0",
-        "@deck.gl/layers": "^8.0.0",
-        "@deck.gl/mesh-layers": "^8.0.0",
-        "@loaders.gl/core": "^3.0.0"
+        "@deck.gl/core": "^9.0.0",
+        "@deck.gl/extensions": "^9.0.0",
+        "@deck.gl/layers": "^9.0.0",
+        "@deck.gl/mesh-layers": "^9.0.0",
+        "@loaders.gl/core": "^4.1.0",
+        "@luma.gl/core": "^9.0.0",
+        "@luma.gl/engine": "^9.0.0"
       }
     },
     "node_modules/@deck.gl/google-maps": {
-      "version": "8.6.6",
-      "resolved": "https://registry.npmjs.org/@deck.gl/google-maps/-/google-maps-8.6.6.tgz",
-      "integrity": "sha512-Ya+T+CxBUopBsp6O7Zdfrmnr/LYiuNjLCSh07ty3ayH1+U09VA3BZ++EWpMHrkI76jCAM1col7EoxgrovX4mYg==",
+      "version": "9.0.6",
+      "resolved": "https://registry.npmjs.org/@deck.gl/google-maps/-/google-maps-9.0.6.tgz",
+      "integrity": "sha512-MteXz7LxoFFzbb5N27K6eE2kescMRxAPMuiQsclmIKrXzagFyf1kbdj5kwdRYGeNmlJTKoXpbfyMS3ARsteUCw==",
+      "dependencies": {
+        "@luma.gl/constants": "^9.0.9",
+        "@math.gl/core": "^4.0.0",
+        "@types/google.maps": "^3.48.6"
+      },
       "peerDependencies": {
-        "@deck.gl/core": "^8.0.0"
+        "@deck.gl/core": "^9.0.0",
+        "@luma.gl/core": "^9.0.0"
       }
     },
     "node_modules/@deck.gl/json": {
-      "version": "8.6.6",
-      "resolved": "https://registry.npmjs.org/@deck.gl/json/-/json-8.6.6.tgz",
-      "integrity": "sha512-6X7TUpTdoqOEvqIG7dO7VX9H0SIi5vjIf+anltBWiQzFsCkAsT3l7Ydw7wES5X++a4O0BcVed9klTXF1IK7zKA==",
+      "version": "9.0.6",
+      "resolved": "https://registry.npmjs.org/@deck.gl/json/-/json-9.0.6.tgz",
+      "integrity": "sha512-9Bw/WQCEaE2PT7AT8dKnWqubyZB4Rt5w2N/D67L8CfSVKkcP1YK4e1mYEbz/zmii9+6kY1tRwSpmJg27mAyVWQ==",
       "dependencies": {
-        "d3-dsv": "^1.0.8",
-        "expression-eval": "^2.0.0"
+        "expression-eval": "^5.0.0"
       },
       "peerDependencies": {
-        "@deck.gl/core": "^8.0.0"
+        "@deck.gl/core": "^9.0.0"
       }
     },
     "node_modules/@deck.gl/layers": {
-      "version": "8.6.6",
-      "resolved": "https://registry.npmjs.org/@deck.gl/layers/-/layers-8.6.6.tgz",
-      "integrity": "sha512-PNaulWRyTvukP+q/jwQ+DwXvhRuWtKUuM/vxHzYgahpEYvkhfGLovhfJWtYm0CvRjBP/BGpH2OBdo50sDYI2dg==",
+      "version": "9.0.6",
+      "resolved": "https://registry.npmjs.org/@deck.gl/layers/-/layers-9.0.6.tgz",
+      "integrity": "sha512-gQ88CIkCxzFiTbSk2p12NT9ZRIOmPO5etqOeDriJONXM4O45yycrmnqcF4Ey2wY2vMYD7zRqWa7eQ0zrxojP1A==",
       "dependencies": {
-        "@loaders.gl/images": "^3.1.5",
-        "@mapbox/tiny-sdf": "^1.1.0",
-        "@math.gl/polygon": "^3.5.6",
-        "earcut": "^2.0.6"
+        "@loaders.gl/images": "^4.1.4",
+        "@loaders.gl/schema": "^4.1.4",
+        "@mapbox/tiny-sdf": "^2.0.5",
+        "@math.gl/core": "^4.0.0",
+        "@math.gl/polygon": "^4.0.0",
+        "@math.gl/web-mercator": "^4.0.0",
+        "earcut": "^2.2.4"
       },
       "peerDependencies": {
-        "@deck.gl/core": "^8.0.0",
-        "@loaders.gl/core": "^3.1.5"
+        "@deck.gl/core": "^9.0.0",
+        "@loaders.gl/core": "^4.1.0",
+        "@luma.gl/core": "^9.0.0",
+        "@luma.gl/engine": "^9.0.0"
       }
     },
     "node_modules/@deck.gl/mapbox": {
-      "version": "8.6.6",
-      "resolved": "https://registry.npmjs.org/@deck.gl/mapbox/-/mapbox-8.6.6.tgz",
-      "integrity": "sha512-VzHlGRNoa9UNP/ARgDBJLKAddmLigu1rPu1EM0BBJdd/ramRMthB6kNnOW200UPy487jknAqzvWlsxhSSZDINg==",
+      "version": "9.0.6",
+      "resolved": "https://registry.npmjs.org/@deck.gl/mapbox/-/mapbox-9.0.6.tgz",
+      "integrity": "sha512-RHLHx0uKCGd6t7L0uyH231A2omOLi70ByfqqZKbpzbwEdk64T2ZLtZFDfcSSTf1x2D6LYm0eQL36yeZkZarLFg==",
+      "dependencies": {
+        "@luma.gl/constants": "^9.0.9",
+        "@math.gl/web-mercator": "^4.0.0"
+      },
       "peerDependencies": {
-        "@deck.gl/core": "^8.0.0"
+        "@deck.gl/core": "^9.0.0",
+        "@luma.gl/core": "^9.0.0"
       }
     },
     "node_modules/@deck.gl/mesh-layers": {
-      "version": "8.6.6",
-      "resolved": "https://registry.npmjs.org/@deck.gl/mesh-layers/-/mesh-layers-8.6.6.tgz",
-      "integrity": "sha512-LLGYTDo5dil6HqL6xaAaiCb3bbv1zbB6dsjvYRm6+qVHG76pKMyzhYBNkTGBEZeGQpaRIItD0RpVbTI800uXiA==",
+      "version": "9.0.6",
+      "resolved": "https://registry.npmjs.org/@deck.gl/mesh-layers/-/mesh-layers-9.0.6.tgz",
+      "integrity": "sha512-F+7HEC5JONOIP6wMvwI6nUzs2Ksp3P4L+Wcy9SQnxKtMWBEnCu6eVaeJ2ZUYMMFNDhRe/fKOViBCn09mLwvsPw==",
       "dependencies": {
-        "@loaders.gl/gltf": "^3.1.5",
-        "@luma.gl/experimental": "^8.5.10",
-        "@luma.gl/shadertools": "^8.5.10"
+        "@loaders.gl/gltf": "^4.1.4",
+        "@luma.gl/gltf": "^9.0.9",
+        "@luma.gl/shadertools": "^9.0.9"
       },
       "peerDependencies": {
-        "@deck.gl/core": "^8.0.0"
+        "@deck.gl/core": "^9.0.0",
+        "@luma.gl/core": "^9.0.0",
+        "@luma.gl/engine": "^9.0.0"
       }
     },
     "node_modules/@deck.gl/react": {
-      "version": "8.6.6",
-      "resolved": "https://registry.npmjs.org/@deck.gl/react/-/react-8.6.6.tgz",
-      "integrity": "sha512-7AU6YPVIuI9aiPGpEIoh7qKjx45omOrguOis+y65nGvy8uclPZDadIZ5NoINUsyXeoDBegCIU/GX7Crzgk769Q==",
+      "version": "9.0.6",
+      "resolved": "https://registry.npmjs.org/@deck.gl/react/-/react-9.0.6.tgz",
+      "integrity": "sha512-vFCsMNzydLE/UwVGOB9lA9a/R21dapSq6V2zX/k0N5gsgqD+9xBLPu8Mh5icYVj303i3yn3E276a818vmP3p4A==",
+      "peerDependencies": {
+        "@deck.gl/core": "^9.0.0",
+        "react": ">=16.3.0",
+        "react-dom": ">=16.3.0"
+      }
+    },
+    "node_modules/@deck.gl/widgets": {
+      "version": "9.0.6",
+      "resolved": "https://registry.npmjs.org/@deck.gl/widgets/-/widgets-9.0.6.tgz",
+      "integrity": "sha512-0F8WgXdI1gMeK+ZdB7mZEDHLuZYVUnKOZpaGyY4L2HNFMe3KI1uH5d6725zuPS8gYg3Rt39RkbkC+gtEyudhkg==",
       "dependencies": {
-        "prop-types": "^15.6.0"
+        "preact": "^10.17.0"
       },
       "peerDependencies": {
-        "@deck.gl/core": "^8.0.0",
-        "react": ">=16.3",
-        "react-dom": ">=16.3"
+        "@deck.gl/core": "^9.0.0"
       }
     },
     "node_modules/@discoveryjs/json-ext": {
@@ -2722,21 +2785,27 @@
       "integrity": "sha512-fuscdXJ9G1qb7W8VdHi+IwRqij3lBkosAm4ydQtEmbY58OzHXqQhvlxqEkoz0yssNVn38bcpRWgA9PP+OGoisw=="
     },
     "node_modules/@loaders.gl/3d-tiles": {
-      "version": "3.4.14",
-      "resolved": "https://registry.npmjs.org/@loaders.gl/3d-tiles/-/3d-tiles-3.4.14.tgz",
-      "integrity": "sha512-cxStTSLIJgRZnkTBYTcp9FPVBQWQlJMzW1LRlaKWiwAHkOKBElszzApIIEvRvZGSrs8k8TUi6BJ1Y41iiANF7w==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/3d-tiles/-/3d-tiles-4.2.0.tgz",
+      "integrity": "sha512-WkHj5m5tk6Ga1AI276UTSzYERy9FL2CXFT08j6IvWGhmjNFAPHvckGlgDS/bciVj0IpsrR61xEtks73Q5YIFlQ==",
       "dependencies": {
-        "@loaders.gl/draco": "3.4.14",
-        "@loaders.gl/gltf": "3.4.14",
-        "@loaders.gl/loader-utils": "3.4.14",
-        "@loaders.gl/math": "3.4.14",
-        "@loaders.gl/tiles": "3.4.14",
-        "@math.gl/core": "^3.5.1",
-        "@math.gl/geospatial": "^3.5.1",
+        "@loaders.gl/compression": "4.2.0",
+        "@loaders.gl/crypto": "4.2.0",
+        "@loaders.gl/draco": "4.2.0",
+        "@loaders.gl/gltf": "4.2.0",
+        "@loaders.gl/images": "4.2.0",
+        "@loaders.gl/loader-utils": "4.2.0",
+        "@loaders.gl/math": "4.2.0",
+        "@loaders.gl/tiles": "4.2.0",
+        "@loaders.gl/zip": "4.2.0",
+        "@math.gl/core": "^4.0.1",
+        "@math.gl/culling": "^4.0.1",
+        "@math.gl/geospatial": "^4.0.1",
+        "@probe.gl/log": "^4.0.4",
         "long": "^5.2.1"
       },
       "peerDependencies": {
-        "@loaders.gl/core": "^3.4.0"
+        "@loaders.gl/core": "^4.0.0"
       }
     },
     "node_modules/@loaders.gl/3d-tiles/node_modules/long": {
@@ -2744,259 +2813,329 @@
       "resolved": "https://registry.npmjs.org/long/-/long-5.2.3.tgz",
       "integrity": "sha512-lcHwpNoggQTObv5apGNCTdJrO69eHOZMi4BNC+rTLER8iHAqGrUVeLh/irVIM7zTw2bOXA8T6uNPeujwOLg/2Q=="
     },
-    "node_modules/@loaders.gl/core": {
-      "version": "3.4.14",
-      "resolved": "https://registry.npmjs.org/@loaders.gl/core/-/core-3.4.14.tgz",
-      "integrity": "sha512-5PFcjv7xC8AYL17juDMrvo8n0Fcwg9s8F4BaM2YCNUsb9RCI2SmLuIFJMcx1GgHO5vL0WiTIKO+JT4n1FuNR6w==",
+    "node_modules/@loaders.gl/compression": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/compression/-/compression-4.2.0.tgz",
+      "integrity": "sha512-7dDR3h/y8HB73HVX4dVybEePzBJKQH6Gpb2VSPptZ0BoftWjctI+BRjKI8+SgPqIsJ0qOHkfvvIVLWalYuuzvA==",
       "dependencies": {
-        "@babel/runtime": "^7.3.1",
-        "@loaders.gl/loader-utils": "3.4.14",
-        "@loaders.gl/worker-utils": "3.4.14",
-        "@probe.gl/log": "^4.0.1"
+        "@loaders.gl/loader-utils": "4.2.0",
+        "@loaders.gl/worker-utils": "4.2.0",
+        "@types/brotli": "^1.3.0",
+        "@types/pako": "^1.0.1",
+        "fflate": "0.7.4",
+        "lzo-wasm": "^0.0.4",
+        "pako": "1.0.11",
+        "snappyjs": "^0.6.1"
+      },
+      "optionalDependencies": {
+        "brotli": "^1.3.2",
+        "lz4js": "^0.2.0",
+        "zstd-codec": "^0.1"
+      },
+      "peerDependencies": {
+        "@loaders.gl/core": "^4.0.0"
+      }
+    },
+    "node_modules/@loaders.gl/core": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/core/-/core-4.2.0.tgz",
+      "integrity": "sha512-HCl+1BdNTcfKGi5+MhZh7ABKhybAjbhsJUsjhJxp2kYEW+2zybHoYPLvZLJFSuu88J/e5FqnL1HmdEFwn6oPXQ==",
+      "dependencies": {
+        "@loaders.gl/loader-utils": "4.2.0",
+        "@loaders.gl/schema": "4.2.0",
+        "@loaders.gl/worker-utils": "4.2.0",
+        "@probe.gl/log": "^4.0.2"
+      }
+    },
+    "node_modules/@loaders.gl/crypto": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/crypto/-/crypto-4.2.0.tgz",
+      "integrity": "sha512-/SJI8NB1SrPWeRdkwtIN3lOzYJgcQw0USmLt+cQhux5lLqxw6MjsLeVU8k559KEhEQvIAvIiYLNtPHflKdQTrA==",
+      "dependencies": {
+        "@loaders.gl/loader-utils": "4.2.0",
+        "@loaders.gl/worker-utils": "4.2.0",
+        "@types/crypto-js": "^4.0.2"
+      },
+      "peerDependencies": {
+        "@loaders.gl/core": "^4.0.0"
       }
     },
     "node_modules/@loaders.gl/draco": {
-      "version": "3.4.14",
-      "resolved": "https://registry.npmjs.org/@loaders.gl/draco/-/draco-3.4.14.tgz",
-      "integrity": "sha512-HwNFFt+dKZqFtzI0uVGvRkudFEZXxybJ+ZRsNkBbzAWoMM5L1TpuLs6DPsqPQUIT9HXNHzov18cZI0gK5bTJpg==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/draco/-/draco-4.2.0.tgz",
+      "integrity": "sha512-nOcAt7/Dj2GeRstQMfWY0E5QMO55DanEbvXhIrSNh8ebk3XqOEMjhIxzy81VadPydSrnDhi6dVmmcEQXbL3Dpw==",
       "dependencies": {
-        "@babel/runtime": "^7.3.1",
-        "@loaders.gl/loader-utils": "3.4.14",
-        "@loaders.gl/schema": "3.4.14",
-        "@loaders.gl/worker-utils": "3.4.14",
-        "draco3d": "1.5.5"
+        "@loaders.gl/loader-utils": "4.2.0",
+        "@loaders.gl/schema": "4.2.0",
+        "@loaders.gl/worker-utils": "4.2.0",
+        "draco3d": "1.5.7"
+      },
+      "peerDependencies": {
+        "@loaders.gl/core": "^4.0.0"
       }
     },
     "node_modules/@loaders.gl/gis": {
-      "version": "3.4.14",
-      "resolved": "https://registry.npmjs.org/@loaders.gl/gis/-/gis-3.4.14.tgz",
-      "integrity": "sha512-5cmhIwioPpSkfNzFRM3PbFDecjpYIhtEOFbryu3rE37npKHLTD2tF4ocQxUPB+QVED6GLwWBdzJIs64UWGrqjw==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/gis/-/gis-4.2.0.tgz",
+      "integrity": "sha512-rwpchq5iAvFShhXsRcd1cZfRFdsA6gNzYwIgwK1UsoXiBzFvCoJ3Hn8b2fn3Z/x3wuTWX83Cxobr8aoVymMzwQ==",
       "dependencies": {
-        "@loaders.gl/loader-utils": "3.4.14",
-        "@loaders.gl/schema": "3.4.14",
+        "@loaders.gl/loader-utils": "4.2.0",
+        "@loaders.gl/schema": "4.2.0",
         "@mapbox/vector-tile": "^1.3.1",
-        "@math.gl/polygon": "^3.5.1",
+        "@math.gl/polygon": "^4.0.0",
         "pbf": "^3.2.1"
+      },
+      "peerDependencies": {
+        "@loaders.gl/core": "^4.0.0"
       }
     },
     "node_modules/@loaders.gl/gltf": {
-      "version": "3.4.14",
-      "resolved": "https://registry.npmjs.org/@loaders.gl/gltf/-/gltf-3.4.14.tgz",
-      "integrity": "sha512-jv+B5S/taiwzXAOu5D9nk1jjU9+JCCr/6/nGguCE2Ya3IX7CI1Nlnp20eKKhW8ZCEokZavMNT0bNbiJ5ahEFjA==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/gltf/-/gltf-4.2.0.tgz",
+      "integrity": "sha512-t15dYnnfmQCGa5mar9KoShVxIVHNH5zAcoLRKpIXhPEvRmOdMeXETwAYQeJ73+IfK/EzY6OwkTlu6Kwm/0EgEw==",
       "dependencies": {
-        "@loaders.gl/draco": "3.4.14",
-        "@loaders.gl/images": "3.4.14",
-        "@loaders.gl/loader-utils": "3.4.14",
-        "@loaders.gl/textures": "3.4.14",
-        "@math.gl/core": "^3.5.1"
+        "@loaders.gl/draco": "4.2.0",
+        "@loaders.gl/images": "4.2.0",
+        "@loaders.gl/loader-utils": "4.2.0",
+        "@loaders.gl/schema": "4.2.0",
+        "@loaders.gl/textures": "4.2.0",
+        "@math.gl/core": "^4.0.0"
+      },
+      "peerDependencies": {
+        "@loaders.gl/core": "^4.0.0"
       }
     },
     "node_modules/@loaders.gl/images": {
-      "version": "3.4.14",
-      "resolved": "https://registry.npmjs.org/@loaders.gl/images/-/images-3.4.14.tgz",
-      "integrity": "sha512-tL447hTWhOKBOB87SE4hvlC8OkbRT0mEaW1a/wIS9f4HnYDa/ycRLMV+nvdvYMZur4isNPam44oiRqi7GcILkg==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/images/-/images-4.2.0.tgz",
+      "integrity": "sha512-0rntM3HheRsvlIESZiy39GDBj6FJ1L85wcMaIzmgre+AlCVZnuc0s619tgsbk+oJ+syPEtbzdyg+Ud05TIXhzA==",
       "dependencies": {
-        "@loaders.gl/loader-utils": "3.4.14"
+        "@loaders.gl/loader-utils": "4.2.0"
+      },
+      "peerDependencies": {
+        "@loaders.gl/core": "^4.0.0"
       }
     },
     "node_modules/@loaders.gl/loader-utils": {
-      "version": "3.4.14",
-      "resolved": "https://registry.npmjs.org/@loaders.gl/loader-utils/-/loader-utils-3.4.14.tgz",
-      "integrity": "sha512-HCTY2/F83RLbZWcTvWLVJ1vke3dl6Bye20HU1AqkA37J2vzHwOZ8kj6eee8eeSkIkf7VIFwjyhVJxe0flQE/Bw==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/loader-utils/-/loader-utils-4.2.0.tgz",
+      "integrity": "sha512-kWM3yMTGLqkBwb/CdWhzQU6P17PZelyFvUm5LtPm1LHo1tVuxutBeo5wl0FuAraJIx4O4/oCR0iNdb4l58wKRg==",
       "dependencies": {
-        "@babel/runtime": "^7.3.1",
-        "@loaders.gl/worker-utils": "3.4.14",
-        "@probe.gl/stats": "^4.0.1"
+        "@loaders.gl/schema": "4.2.0",
+        "@loaders.gl/worker-utils": "4.2.0",
+        "@probe.gl/stats": "^4.0.2"
+      },
+      "peerDependencies": {
+        "@loaders.gl/core": "^4.0.0"
       }
     },
     "node_modules/@loaders.gl/math": {
-      "version": "3.4.14",
-      "resolved": "https://registry.npmjs.org/@loaders.gl/math/-/math-3.4.14.tgz",
-      "integrity": "sha512-OBEVX6Q5pMipbCAiZyX2+q1zRd0nw8M2dclpny05on8700OaKMwfs47wEUnbfCU3iyHad3sgsAxN3EIh+kuo9Q==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/math/-/math-4.2.0.tgz",
+      "integrity": "sha512-Z3NRoVJcmKPrkSfsd9bwpvRmWy/VI6MjD/eZ4AWObqtbVPsbaupUvk5Cc26djYkJ373nCE38D8jE25+lKvPqAQ==",
       "dependencies": {
-        "@loaders.gl/images": "3.4.14",
-        "@loaders.gl/loader-utils": "3.4.14",
-        "@math.gl/core": "^3.5.1"
+        "@loaders.gl/images": "4.2.0",
+        "@loaders.gl/loader-utils": "4.2.0",
+        "@math.gl/core": "^4.0.0"
+      },
+      "peerDependencies": {
+        "@loaders.gl/core": "^4.0.0"
       }
     },
     "node_modules/@loaders.gl/mvt": {
-      "version": "3.4.14",
-      "resolved": "https://registry.npmjs.org/@loaders.gl/mvt/-/mvt-3.4.14.tgz",
-      "integrity": "sha512-tozGmWvsJacjaLavjX4S/5yNDV9S4wJb7+vPG/nXWX2gTtgZ1mxcFQAtAJjokqpy37d1ZhLt+TXh0HrLoTmRgw==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/mvt/-/mvt-4.2.0.tgz",
+      "integrity": "sha512-W/JHmWSP4hwWJb3xWtGqjTvn/TPSOhA651FptXT9SXWyLglEwKCrlSy4uTr1fFu1fxSJXxo6cQmWVVmVmYN7VA==",
       "dependencies": {
-        "@loaders.gl/gis": "3.4.14",
-        "@loaders.gl/loader-utils": "3.4.14",
-        "@loaders.gl/schema": "3.4.14",
-        "@math.gl/polygon": "^3.5.1",
+        "@loaders.gl/gis": "4.2.0",
+        "@loaders.gl/images": "4.2.0",
+        "@loaders.gl/loader-utils": "4.2.0",
+        "@loaders.gl/schema": "4.2.0",
+        "@math.gl/polygon": "^4.0.0",
         "pbf": "^3.2.1"
+      },
+      "peerDependencies": {
+        "@loaders.gl/core": "^4.0.0"
       }
     },
     "node_modules/@loaders.gl/schema": {
-      "version": "3.4.14",
-      "resolved": "https://registry.npmjs.org/@loaders.gl/schema/-/schema-3.4.14.tgz",
-      "integrity": "sha512-r6BEDfUvbvzgUnh/MtkR5RzrkIwo1x1jtPFRTSJVsIZO7arXXlu3blffuv5ppEkKpNZ1Xzd9WtHp/JIkuctsmw==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/schema/-/schema-4.2.0.tgz",
+      "integrity": "sha512-xM5PY3k9UvyXz6rgCyouGSIbfzdsmrR2zYEhI5prFYwgjnOJX0D5Wz4TpsuNQaVpsAGC6cZXgQU6nmhScQYJyQ==",
       "dependencies": {
         "@types/geojson": "^7946.0.7"
+      },
+      "peerDependencies": {
+        "@loaders.gl/core": "^4.0.0"
       }
     },
     "node_modules/@loaders.gl/terrain": {
-      "version": "3.4.14",
-      "resolved": "https://registry.npmjs.org/@loaders.gl/terrain/-/terrain-3.4.14.tgz",
-      "integrity": "sha512-vhchEVkPaWXnqd2ofujG2AEnBsk4hEw6LWSaFY7E3VMzNhI9l2EHvyU3+Hs03jYbXM4oLlQPGqd/T7x+5IMtig==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/terrain/-/terrain-4.2.0.tgz",
+      "integrity": "sha512-j7LA5kU5Y4ZWEEXzpQOnmyIaQoIh07AkQj2FSnrEM0AwYgq9xSVa31otPk5WegEzOwbUOsWgHLtxju52HDUHJQ==",
       "dependencies": {
-        "@babel/runtime": "^7.3.1",
-        "@loaders.gl/images": "3.4.14",
-        "@loaders.gl/loader-utils": "3.4.14",
-        "@loaders.gl/schema": "3.4.14",
+        "@loaders.gl/images": "4.2.0",
+        "@loaders.gl/loader-utils": "4.2.0",
+        "@loaders.gl/schema": "4.2.0",
         "@mapbox/martini": "^0.2.0"
+      },
+      "peerDependencies": {
+        "@loaders.gl/core": "^4.0.0"
       }
     },
     "node_modules/@loaders.gl/textures": {
-      "version": "3.4.14",
-      "resolved": "https://registry.npmjs.org/@loaders.gl/textures/-/textures-3.4.14.tgz",
-      "integrity": "sha512-iKDHL2ZlOUud4/e3g0p0SyvkukznopYy6La3O6I9vDfKp8peuKMRRcTfFfd/zH0OqQC0hIhCXNz46vRLu7h6ng==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/textures/-/textures-4.2.0.tgz",
+      "integrity": "sha512-T+MoSyVCUQAjPTbDRnEXhQxyn5iU5nMzYiMI59VElp43WkShU3s7k4OB6HhAFPfIeqlD0ZPnm3ecgYZ/BZbZ6w==",
       "dependencies": {
-        "@loaders.gl/images": "3.4.14",
-        "@loaders.gl/loader-utils": "3.4.14",
-        "@loaders.gl/schema": "3.4.14",
-        "@loaders.gl/worker-utils": "3.4.14",
+        "@loaders.gl/images": "4.2.0",
+        "@loaders.gl/loader-utils": "4.2.0",
+        "@loaders.gl/schema": "4.2.0",
+        "@loaders.gl/worker-utils": "4.2.0",
+        "@math.gl/types": "^4.0.1",
         "ktx-parse": "^0.0.4",
         "texture-compressor": "^1.0.2"
+      },
+      "peerDependencies": {
+        "@loaders.gl/core": "^4.0.0"
       }
     },
     "node_modules/@loaders.gl/tiles": {
-      "version": "3.4.14",
-      "resolved": "https://registry.npmjs.org/@loaders.gl/tiles/-/tiles-3.4.14.tgz",
-      "integrity": "sha512-an3scxl65r74LW4WoIGgluBmQpMY9eb381y9mZmREphTP6bWEj96fL/tiR+G6TiE6HJqTv8O3PH6xwI9OQmEJg==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/tiles/-/tiles-4.2.0.tgz",
+      "integrity": "sha512-PjOFSZfiA5ioqRObF0sPVwnqnrCRU9Mw1gt36buga4UF7AYvbirKY/BysrM1NkqCSG0SWNbMGUdhBn41jlQv5g==",
       "dependencies": {
-        "@loaders.gl/loader-utils": "3.4.14",
-        "@loaders.gl/math": "3.4.14",
-        "@math.gl/core": "^3.5.1",
-        "@math.gl/culling": "^3.5.1",
-        "@math.gl/geospatial": "^3.5.1",
-        "@math.gl/web-mercator": "^3.5.1",
-        "@probe.gl/stats": "^4.0.1"
+        "@loaders.gl/loader-utils": "4.2.0",
+        "@loaders.gl/math": "4.2.0",
+        "@math.gl/core": "^4.0.0",
+        "@math.gl/culling": "^4.0.0",
+        "@math.gl/geospatial": "^4.0.0",
+        "@math.gl/web-mercator": "^4.0.0",
+        "@probe.gl/stats": "^4.0.2"
       },
       "peerDependencies": {
-        "@loaders.gl/core": "^3.4.0"
+        "@loaders.gl/core": "^4.0.0"
+      }
+    },
+    "node_modules/@loaders.gl/wms": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/wms/-/wms-4.2.0.tgz",
+      "integrity": "sha512-dN/q2rCaY9m3Sg06uq6Jq96reyYc+A8WwaMs0ehWIg7fQ1R/mh2cHCvmx/fBnY97fmIMPjrd+7wG3hluYcnssw==",
+      "dependencies": {
+        "@loaders.gl/images": "4.2.0",
+        "@loaders.gl/loader-utils": "4.2.0",
+        "@loaders.gl/schema": "4.2.0",
+        "@loaders.gl/xml": "4.2.0",
+        "@turf/rewind": "^5.1.5",
+        "deep-strict-equal": "^0.2.0"
+      },
+      "peerDependencies": {
+        "@loaders.gl/core": "^4.0.0"
       }
     },
     "node_modules/@loaders.gl/worker-utils": {
-      "version": "3.4.14",
-      "resolved": "https://registry.npmjs.org/@loaders.gl/worker-utils/-/worker-utils-3.4.14.tgz",
-      "integrity": "sha512-PUSwxoAYbskisXd0KfYEQ902b0igBA2UAWdP6PzPvY+tJmobfh74dTNwrrBQ1rGXQxxmGx6zc6/ksX6mlIzIrg==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/worker-utils/-/worker-utils-4.2.0.tgz",
+      "integrity": "sha512-sTfalI6utDO7/0i89bE5Ex+uXK6Kull7U3IozkDNPSn6JhNwCvkujhcmQWEFxEPY0CQRVZBq95pjbCYbYYLJpQ==",
+      "peerDependencies": {
+        "@loaders.gl/core": "^4.0.0"
+      }
+    },
+    "node_modules/@loaders.gl/xml": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/xml/-/xml-4.2.0.tgz",
+      "integrity": "sha512-du9s+dubvLsJPzSvugUY3WwBuDvv3ZKOVtLaiakeqsQeOwbcvXa6LQgSR2nT79KQ2DL1+U51ctQHjtXLyOc6PA==",
       "dependencies": {
-        "@babel/runtime": "^7.3.1"
+        "@loaders.gl/loader-utils": "4.2.0",
+        "@loaders.gl/schema": "4.2.0",
+        "fast-xml-parser": "^4.2.5"
+      },
+      "peerDependencies": {
+        "@loaders.gl/core": "^4.0.0"
+      }
+    },
+    "node_modules/@loaders.gl/zip": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/zip/-/zip-4.2.0.tgz",
+      "integrity": "sha512-BrdGE0AIt9ZwlLMx7knZ/fsEUr2bL5RHDYE2f4A4vlH3LBRnXaiZDSfMPwQWJinEKpSHRnysGwqD6zSSUyhVHQ==",
+      "dependencies": {
+        "@loaders.gl/compression": "4.2.0",
+        "@loaders.gl/crypto": "4.2.0",
+        "@loaders.gl/loader-utils": "4.2.0",
+        "jszip": "^3.1.5",
+        "md5": "^2.3.0"
+      },
+      "peerDependencies": {
+        "@loaders.gl/core": "^4.0.0"
       }
     },
     "node_modules/@luma.gl/constants": {
-      "version": "8.5.21",
-      "resolved": "https://registry.npmjs.org/@luma.gl/constants/-/constants-8.5.21.tgz",
-      "integrity": "sha512-aJxayGxTT+IRd1vfpcgD/cKSCiVJjBNiuiChS96VulrmCvkzUOLvYXr42y5qKB4RyR7vOIda5uQprNzoHrhQAA=="
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/@luma.gl/constants/-/constants-9.0.9.tgz",
+      "integrity": "sha512-o8NgH4F//e2wVWyZoYmaoopoTejDEITBP78fJtU2ivmCW1viCvByUawEXISPzsekHosDYo9q1/XFjmusXZa3fQ=="
     },
     "node_modules/@luma.gl/core": {
-      "version": "8.5.21",
-      "resolved": "https://registry.npmjs.org/@luma.gl/core/-/core-8.5.21.tgz",
-      "integrity": "sha512-11jQJQEMoR/IN2oIsd4zFxiQJk6FE+xgVIMUcsCTBuzafTtQZ8Po9df8mt+MVewpDyBlTVs6g8nxHRH4np1ukA==",
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/@luma.gl/core/-/core-9.0.9.tgz",
+      "integrity": "sha512-G0N4+bSWLU6gt3grgzF5xf+vMnfYaryHFLDkAeZV5kJ2helnfzUsjwUKCEYk36V2vygu7TEXlByYgwestB7+Ew==",
       "dependencies": {
-        "@babel/runtime": "^7.0.0",
-        "@luma.gl/constants": "8.5.21",
-        "@luma.gl/engine": "8.5.21",
-        "@luma.gl/gltools": "8.5.21",
-        "@luma.gl/shadertools": "8.5.21",
-        "@luma.gl/webgl": "8.5.21"
+        "@math.gl/types": "^4.0.0",
+        "@probe.gl/env": "^4.0.2",
+        "@probe.gl/log": "^4.0.2",
+        "@probe.gl/stats": "^4.0.2",
+        "@types/offscreencanvas": "^2019.6.4"
       }
     },
     "node_modules/@luma.gl/engine": {
-      "version": "8.5.21",
-      "resolved": "https://registry.npmjs.org/@luma.gl/engine/-/engine-8.5.21.tgz",
-      "integrity": "sha512-IG3WQSKXFNUEs8QG7ZjHtGiOtsakUu+BAxtJ6997A6/F06yynZ44tPe5NU70jG9Yfu3kV0LykPZg7hO3vXZDiA==",
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/@luma.gl/engine/-/engine-9.0.9.tgz",
+      "integrity": "sha512-4qW4OCYaGZJ/iGqerAtnP8FzcNtnXvv+aShLkE4ay2D4zdOIML5kZSLslmU/ByZ3FR606k0c5AjTBOgZ77lkiQ==",
       "dependencies": {
-        "@babel/runtime": "^7.0.0",
-        "@luma.gl/constants": "8.5.21",
-        "@luma.gl/gltools": "8.5.21",
-        "@luma.gl/shadertools": "8.5.21",
-        "@luma.gl/webgl": "8.5.21",
-        "@math.gl/core": "^3.5.0",
-        "@probe.gl/env": "^3.5.0",
-        "@probe.gl/stats": "^3.5.0",
-        "@types/offscreencanvas": "^2019.7.0"
-      }
-    },
-    "node_modules/@luma.gl/engine/node_modules/@probe.gl/stats": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/@probe.gl/stats/-/stats-3.6.0.tgz",
-      "integrity": "sha512-JdALQXB44OP4kUBN/UrQgzbJe4qokbVF4Y8lkIA8iVCFnjVowWIgkD/z/0QO65yELT54tTrtepw1jScjKB+rhQ==",
-      "dependencies": {
-        "@babel/runtime": "^7.0.0"
-      }
-    },
-    "node_modules/@luma.gl/experimental": {
-      "version": "8.5.21",
-      "resolved": "https://registry.npmjs.org/@luma.gl/experimental/-/experimental-8.5.21.tgz",
-      "integrity": "sha512-uFKPChGofyihOKxtqJy78QCQCDFnuMTK4QHrUX/qiTnvFSO8BgtTUevKvWGN9lBvq+uDD0lSieeF9yBzhQfAzw==",
-      "dependencies": {
-        "@luma.gl/constants": "8.5.21",
-        "@math.gl/core": "^3.5.0",
-        "earcut": "^2.0.6"
+        "@luma.gl/shadertools": "9.0.9",
+        "@math.gl/core": "^4.0.0",
+        "@probe.gl/log": "^4.0.2",
+        "@probe.gl/stats": "^4.0.2"
       },
       "peerDependencies": {
-        "@loaders.gl/gltf": "^3.0.0",
-        "@loaders.gl/images": "^3.0.0",
-        "@luma.gl/engine": "^8.4.0",
-        "@luma.gl/gltools": "^8.4.0",
-        "@luma.gl/shadertools": "^8.4.0",
-        "@luma.gl/webgl": "^8.4.0"
+        "@luma.gl/core": "^9.0.0"
       }
     },
-    "node_modules/@luma.gl/gltools": {
-      "version": "8.5.21",
-      "resolved": "https://registry.npmjs.org/@luma.gl/gltools/-/gltools-8.5.21.tgz",
-      "integrity": "sha512-6qZ0LaT2Mxa4AJT5F44TFoaziokYiHUwO45vnM/NYUOIu9xevcmS6VtToawytMEACGL6PDeDyVqP3Y80SDzq5g==",
+    "node_modules/@luma.gl/gltf": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/@luma.gl/gltf/-/gltf-9.0.9.tgz",
+      "integrity": "sha512-QuV4gbxIZ8qGOmZsf9DGvavogQUyplpDVAs38eczBBqIKCGFq2d+mOIQMmn1SWFF0RjicjyjnQ2KAFWgdy2jIQ==",
       "dependencies": {
-        "@babel/runtime": "^7.0.0",
-        "@luma.gl/constants": "8.5.21",
-        "@probe.gl/env": "^3.5.0",
-        "@probe.gl/log": "^3.5.0",
-        "@types/offscreencanvas": "^2019.7.0"
-      }
-    },
-    "node_modules/@luma.gl/gltools/node_modules/@probe.gl/log": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/@probe.gl/log/-/log-3.6.0.tgz",
-      "integrity": "sha512-hjpyenpEvOdowgZ1qMeCJxfRD4JkKdlXz0RC14m42Un62NtOT+GpWyKA4LssT0+xyLULCByRAtG2fzZorpIAcA==",
-      "dependencies": {
-        "@babel/runtime": "^7.0.0",
-        "@probe.gl/env": "3.6.0"
+        "@loaders.gl/textures": "^4.1.0",
+        "@luma.gl/shadertools": "9.0.9",
+        "@math.gl/core": "^4.0.0"
+      },
+      "peerDependencies": {
+        "@luma.gl/core": "^9.0.0",
+        "@luma.gl/engine": "^9.0.0"
       }
     },
     "node_modules/@luma.gl/shadertools": {
-      "version": "8.5.21",
-      "resolved": "https://registry.npmjs.org/@luma.gl/shadertools/-/shadertools-8.5.21.tgz",
-      "integrity": "sha512-WQah7yFDJ8cNCLPYpIm3r0wSlXLvjoA279fcknmATvvkW3/i8PcCJ/nYEBJO3hHEwwMQxD16+YZu/uwGiifLMg==",
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/@luma.gl/shadertools/-/shadertools-9.0.9.tgz",
+      "integrity": "sha512-99wfDMtkIeWziAf96UrqXteJi4uBFvMN0TdU8TvTv0V6BJRjd1xZVWnF9Xx2D+DPH9Mmn4q/hQH0NJ0sQlYeHw==",
       "dependencies": {
-        "@babel/runtime": "^7.0.0",
-        "@math.gl/core": "^3.5.0"
+        "@math.gl/core": "^4.0.0",
+        "@math.gl/types": "^4.0.0"
+      },
+      "peerDependencies": {
+        "@luma.gl/core": "^9.0.0"
       }
     },
     "node_modules/@luma.gl/webgl": {
-      "version": "8.5.21",
-      "resolved": "https://registry.npmjs.org/@luma.gl/webgl/-/webgl-8.5.21.tgz",
-      "integrity": "sha512-ZVLO4W5UuaOlzZIwmFWhnmZ1gYoU97a+heMqxLrSSmCUAsSu3ZETUex9gOmzdM1WWxcdWaa3M68rvKCNEgwz0Q==",
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/@luma.gl/webgl/-/webgl-9.0.9.tgz",
+      "integrity": "sha512-dP91Md5u6OnK3PFt0h1uqcxWh3T/COBHyZ5OcAirRUB1laFdzhdXUWbtuvLgpF6b7o0MsaEUcXaAbYf+e7lEzA==",
       "dependencies": {
-        "@babel/runtime": "^7.0.0",
-        "@luma.gl/constants": "8.5.21",
-        "@luma.gl/gltools": "8.5.21",
-        "@probe.gl/env": "^3.5.0",
-        "@probe.gl/stats": "^3.5.0"
-      }
-    },
-    "node_modules/@luma.gl/webgl/node_modules/@probe.gl/stats": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/@probe.gl/stats/-/stats-3.6.0.tgz",
-      "integrity": "sha512-JdALQXB44OP4kUBN/UrQgzbJe4qokbVF4Y8lkIA8iVCFnjVowWIgkD/z/0QO65yELT54tTrtepw1jScjKB+rhQ==",
-      "dependencies": {
-        "@babel/runtime": "^7.0.0"
+        "@luma.gl/constants": "9.0.9",
+        "@probe.gl/env": "^4.0.2"
+      },
+      "peerDependencies": {
+        "@luma.gl/core": "^9.0.0"
       }
     },
     "node_modules/@mapbox/martini": {
@@ -3009,10 +3148,18 @@
       "resolved": "https://registry.npmjs.org/@mapbox/point-geometry/-/point-geometry-0.1.0.tgz",
       "integrity": "sha512-6j56HdLTwWGO0fJPlrZtdU/B13q8Uwmo18Ck2GnGgN9PCFyKTZ3UbXeEdRFh18i9XQ92eH2VdtpJHpBD3aripQ=="
     },
+    "node_modules/@mapbox/tile-cover": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@mapbox/tile-cover/-/tile-cover-3.0.1.tgz",
+      "integrity": "sha512-R8aoFY/87HWBOL9E2eBqzOY2lpfWYXCcTNgBpIxAv67rqQeD4IfnHD0iPXg/Z1cqXrklegEYZCp/7ZR/RsWqBQ==",
+      "dependencies": {
+        "tilebelt": "^1.0.1"
+      }
+    },
     "node_modules/@mapbox/tiny-sdf": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/@mapbox/tiny-sdf/-/tiny-sdf-1.2.5.tgz",
-      "integrity": "sha512-cD8A/zJlm6fdJOk6DqPUV8mcpyJkRz2x2R+/fYcWDYG3oWbG7/L7Yl/WqQ1VZCjnL9OTIMAn6c+BC5Eru4sQEw=="
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@mapbox/tiny-sdf/-/tiny-sdf-2.0.6.tgz",
+      "integrity": "sha512-qMqa27TLw+ZQz5Jk+RcwZGH7BQf5G/TrutJhspsca/3SHwmgKQ1iq+d3Jxz5oysPVYTGP6aXxCo5Lk9Er6YBAA=="
     },
     "node_modules/@mapbox/vector-tile": {
       "version": "1.3.1",
@@ -3023,56 +3170,51 @@
       }
     },
     "node_modules/@math.gl/core": {
-      "version": "3.6.3",
-      "resolved": "https://registry.npmjs.org/@math.gl/core/-/core-3.6.3.tgz",
-      "integrity": "sha512-jBABmDkj5uuuE0dTDmwwss7Cup5ZwQ6Qb7h1pgvtkEutTrhkcv8SuItQNXmF45494yIHeoGue08NlyeY6wxq2A==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@math.gl/core/-/core-4.0.1.tgz",
+      "integrity": "sha512-9IewNjR9V66o+gYIIq5agFoHy6ZT6DRpRGQBfsUpZz4glAqOjVt64he8GGzjpmqfT+kKT4qwQ7nQl/hZLF15qA==",
       "dependencies": {
-        "@babel/runtime": "^7.12.0",
-        "@math.gl/types": "3.6.3",
-        "gl-matrix": "^3.4.0"
+        "@math.gl/types": "4.0.1"
       }
     },
     "node_modules/@math.gl/culling": {
-      "version": "3.6.3",
-      "resolved": "https://registry.npmjs.org/@math.gl/culling/-/culling-3.6.3.tgz",
-      "integrity": "sha512-3UERXHbaPlM6pnTk2MI7LeQ5CoelDZzDzghTTcv+HdQCZsT/EOEuEdYimETHtSxiyiOmsX2Un65UBLYT/rbKZg==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@math.gl/culling/-/culling-4.0.1.tgz",
+      "integrity": "sha512-lv83sMKp0n1HjORhuNtWgX9ylYyj+/zHEPF0xxRXZvcpurB85fhgFLhvR81KLjmSbhQmFgzl0fZe7Ei3WxEP5Q==",
       "dependencies": {
-        "@babel/runtime": "^7.12.0",
-        "@math.gl/core": "3.6.3",
-        "gl-matrix": "^3.4.0"
+        "@math.gl/core": "4.0.1"
       }
     },
     "node_modules/@math.gl/geospatial": {
-      "version": "3.6.3",
-      "resolved": "https://registry.npmjs.org/@math.gl/geospatial/-/geospatial-3.6.3.tgz",
-      "integrity": "sha512-6xf657lJnaecSarSzn02t0cnsCSkWb+39m4+im96v20dZTrLCWZ2glDQVzfuL91meDnDXjH4oyvynp12Mj5MFg==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@math.gl/geospatial/-/geospatial-4.0.1.tgz",
+      "integrity": "sha512-FfTUMk8uRlBa4W3dMSFwPjRgdEBnOeVjBr3mcGqb3lHA/PPMvKuE+o7OJfA61Wj6ItuZqCEZHbLbA3WRAENoqQ==",
       "dependencies": {
-        "@babel/runtime": "^7.12.0",
-        "@math.gl/core": "3.6.3",
-        "gl-matrix": "^3.4.0"
+        "@math.gl/core": "4.0.1"
       }
     },
     "node_modules/@math.gl/polygon": {
-      "version": "3.6.3",
-      "resolved": "https://registry.npmjs.org/@math.gl/polygon/-/polygon-3.6.3.tgz",
-      "integrity": "sha512-FivQ1ZnYcAss1wVifOkHP/ZnlfQy1IL/769uzNtiHxwUbW0kZG3yyOZ9I7fwyzR5Hvqt3ErJKHjSYZr0uVlz5g==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@math.gl/polygon/-/polygon-4.0.1.tgz",
+      "integrity": "sha512-pwtEbwW3N5qy09K/1FwRYW7M2u9XMPBfIe8BNpkbJh8uH3DPXQdT4uCNFiwrQPPQUQTDdlQyLu/0mRHm2R/fbg==",
       "dependencies": {
-        "@math.gl/core": "3.6.3"
+        "@math.gl/core": "4.0.1"
       }
+    },
+    "node_modules/@math.gl/sun": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@math.gl/sun/-/sun-4.0.1.tgz",
+      "integrity": "sha512-nDkQZ9PKd5iMySRM1j01hYG6MwA/MkKXZe4JvArggWUtPXL6nCcPSeiifPXQGIvE9eZdQkbn81StNY9q5l0cFg=="
     },
     "node_modules/@math.gl/types": {
-      "version": "3.6.3",
-      "resolved": "https://registry.npmjs.org/@math.gl/types/-/types-3.6.3.tgz",
-      "integrity": "sha512-3uWLVXHY3jQxsXCr/UCNPSc2BG0hNUljhmOBt9l+lNFDp7zHgm0cK2Tw4kj2XfkJy4TgwZTBGwRDQgWEbLbdTA=="
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@math.gl/types/-/types-4.0.1.tgz",
+      "integrity": "sha512-E9qBKAjVBiZD8Is7TbygiLGtYBP3GSLus6RUJSuzFQegdYXeVagvrs4UkBJxhrRAxw4crfH0Tq7IhTMKuuJNQw=="
     },
     "node_modules/@math.gl/web-mercator": {
-      "version": "3.6.3",
-      "resolved": "https://registry.npmjs.org/@math.gl/web-mercator/-/web-mercator-3.6.3.tgz",
-      "integrity": "sha512-UVrkSOs02YLehKaehrxhAejYMurehIHPfFQvPFZmdJHglHOU4V2cCUApTVEwOksvCp161ypEqVp+9H6mGhTTcw==",
-      "dependencies": {
-        "@babel/runtime": "^7.12.0",
-        "gl-matrix": "^3.4.0"
-      }
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@math.gl/web-mercator/-/web-mercator-4.0.1.tgz",
+      "integrity": "sha512-eJ0nDw8140kJorf8ASyKRC53rI+UG6vPxpsKJiGRD6lXsoKTeKYebeEAXiGDWTvi2AMe6+xngxTqqwm58fL3Fw=="
     },
     "node_modules/@next/bundle-analyzer": {
       "version": "14.1.0",
@@ -3274,37 +3416,22 @@
       "dev": true
     },
     "node_modules/@probe.gl/env": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/@probe.gl/env/-/env-3.6.0.tgz",
-      "integrity": "sha512-4tTZYUg/8BICC3Yyb9rOeoKeijKbZHRXBEKObrfPmX4sQmYB15ZOUpoVBhAyJkOYVAM8EkPci6Uw5dLCwx2BEQ==",
-      "dependencies": {
-        "@babel/runtime": "^7.0.0"
-      }
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@probe.gl/env/-/env-4.0.9.tgz",
+      "integrity": "sha512-AOmVMD0/j78mX+k4+qX7ZhE0sY9H+EaJgIO6trik0BwV6VcrwxTGCGFAeuRsIGhETDnye06tkLXccYatYxAYwQ=="
     },
     "node_modules/@probe.gl/log": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/@probe.gl/log/-/log-4.0.4.tgz",
-      "integrity": "sha512-WpmXl6njlBMwrm8HBh/b4kSp/xnY1VVmeT4PWUKF+RkVbFuKQbsU11dA1IxoMd7gSY+5DGIwxGfAv1H5OMzA4A==",
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@probe.gl/log/-/log-4.0.9.tgz",
+      "integrity": "sha512-ebuZaodSRE9aC+3bVC7cKRHT8garXeT1jTbj1R5tQRqQYc9iGeT3iemVOHx5bN9Q6gAs/0j54iPI+1DvWMAW4A==",
       "dependencies": {
-        "@babel/runtime": "^7.0.0",
-        "@probe.gl/env": "4.0.4"
-      }
-    },
-    "node_modules/@probe.gl/log/node_modules/@probe.gl/env": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/@probe.gl/env/-/env-4.0.4.tgz",
-      "integrity": "sha512-sYNGqesDfWD6dFP5oNZtTeFA4Z6ak5T4a8BNPdNhoqy7PK9w70JHrb6mv+RKWqKXq33KiwCDWL7fYxx2HuEH2w==",
-      "dependencies": {
-        "@babel/runtime": "^7.0.0"
+        "@probe.gl/env": "4.0.9"
       }
     },
     "node_modules/@probe.gl/stats": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/@probe.gl/stats/-/stats-4.0.4.tgz",
-      "integrity": "sha512-SDuSY/D4yDL6LQDa69l/GCcnZLRiGYdyvYkxWb0CgnzTPdPrcdrzGkzkvpC3zsA4fEFw2smlDje370QGHwlisg==",
-      "dependencies": {
-        "@babel/runtime": "^7.0.0"
-      }
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@probe.gl/stats/-/stats-4.0.9.tgz",
+      "integrity": "sha512-Q9Xt/sJUQaMsbjRKjOscv2t7wXIymTrOEJ4a3da4FTCn7bkKvcdxdyFAQySCrtPxE+YZ5I5lXpWPgv9BwmpE1g=="
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
       "version": "4.14.1",
@@ -4049,6 +4176,56 @@
         "node": ">=10.13.0"
       }
     },
+    "node_modules/@turf/boolean-clockwise": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/boolean-clockwise/-/boolean-clockwise-5.1.5.tgz",
+      "integrity": "sha512-FqbmEEOJ4rU4/2t7FKx0HUWmjFEVqR+NJrFP7ymGSjja2SQ7Q91nnBihGuT+yuHHl6ElMjQ3ttsB/eTmyCycxA==",
+      "dependencies": {
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5"
+      }
+    },
+    "node_modules/@turf/clone": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/clone/-/clone-5.1.5.tgz",
+      "integrity": "sha512-//pITsQ8xUdcQ9pVb4JqXiSqG4dos5Q9N4sYFoWghX21tfOV2dhc5TGqYOhnHrQS7RiKQL1vQ48kIK34gQ5oRg==",
+      "dependencies": {
+        "@turf/helpers": "^5.1.5"
+      }
+    },
+    "node_modules/@turf/helpers": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-5.1.5.tgz",
+      "integrity": "sha512-/lF+JR+qNDHZ8bF9d+Cp58nxtZWJ3sqFe6n3u3Vpj+/0cqkjk4nXKYBSY0azm+GIYB5mWKxUXvuP/m0ZnKj1bw=="
+    },
+    "node_modules/@turf/invariant": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@turf/invariant/-/invariant-5.2.0.tgz",
+      "integrity": "sha512-28RCBGvCYsajVkw2EydpzLdcYyhSA77LovuOvgCJplJWaNVyJYH6BOR3HR9w50MEkPqb/Vc/jdo6I6ermlRtQA==",
+      "dependencies": {
+        "@turf/helpers": "^5.1.5"
+      }
+    },
+    "node_modules/@turf/meta": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@turf/meta/-/meta-5.2.0.tgz",
+      "integrity": "sha512-ZjQ3Ii62X9FjnK4hhdsbT+64AYRpaI8XMBMcyftEOGSmPMUVnkbvuv3C9geuElAXfQU7Zk1oWGOcrGOD9zr78Q==",
+      "dependencies": {
+        "@turf/helpers": "^5.1.5"
+      }
+    },
+    "node_modules/@turf/rewind": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/rewind/-/rewind-5.1.5.tgz",
+      "integrity": "sha512-Gdem7JXNu+G4hMllQHXRFRihJl3+pNl7qY+l4qhQFxq+hiU1cQoVFnyoleIqWKIrdK/i2YubaSwc3SCM7N5mMw==",
+      "dependencies": {
+        "@turf/boolean-clockwise": "^5.1.5",
+        "@turf/clone": "^5.1.5",
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5",
+        "@turf/meta": "^5.1.5"
+      }
+    },
     "node_modules/@types/aria-query": {
       "version": "5.0.4",
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
@@ -4092,15 +4269,56 @@
         "@babel/types": "^7.20.7"
       }
     },
+    "node_modules/@types/brotli": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/@types/brotli/-/brotli-1.3.4.tgz",
+      "integrity": "sha512-cKYjgaS2DMdCKF7R0F5cgx1nfBYObN2ihIuPGQ4/dlIY6RpV7OWNwe9L8V4tTVKL2eZqOkNM9FM/rgTvLf4oXw==",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/crypto-js": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@types/crypto-js/-/crypto-js-4.2.2.tgz",
+      "integrity": "sha512-sDOLlVbHhXpAUAL0YHDUUwDZf3iN4Bwi4W6a0W0b+QcAezUbRtH4FVb+9J4h+XFPW7l/gQ9F8qC7P+Ec4k8QVQ=="
+    },
+    "node_modules/@types/d3-array": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.1.tgz",
+      "integrity": "sha512-Y2Jn2idRrLzUfAKV2LyRImR+y4oa2AntrgID95SHJxuMUrkNXmanDSed71sRNZysveJVt1hLLemQZIady0FpEg=="
+    },
+    "node_modules/@types/d3-color": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-1.4.5.tgz",
+      "integrity": "sha512-5sNP3DmtSnSozxcjqmzQKsDOuVJXZkceo1KJScDc1982kk/TS9mTPc6lpli1gTu1MIBF1YWutpHpjucNWcIj5g=="
+    },
+    "node_modules/@types/d3-scale": {
+      "version": "3.3.5",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-3.3.5.tgz",
+      "integrity": "sha512-YOpKj0kIEusRf7ofeJcSZQsvKbnTwpe1DUF+P2qsotqG53kEsjm7EzzliqQxMkAWdkZcHrg5rRhB4JiDOQPX+A==",
+      "dependencies": {
+        "@types/d3-time": "^2"
+      }
+    },
+    "node_modules/@types/d3-time": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-2.1.4.tgz",
+      "integrity": "sha512-BTfLsxTeo7yFxI/haOOf1ZwJ6xKgQLT9dCp+EcmQv87Gox6X+oKl4mLKfO6fnWm3P22+A6DknMNEZany8ql2Rw=="
+    },
     "node_modules/@types/estree": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.5.tgz",
       "integrity": "sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw=="
     },
     "node_modules/@types/geojson": {
-      "version": "7946.0.13",
-      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.13.tgz",
-      "integrity": "sha512-bmrNrgKMOhM3WsafmbGmC+6dsF2Z308vLFsQ3a/bT8X8Sv5clVYpPars/UPq+sAaJP+5OoLAYgwbkS5QEJdLUQ=="
+      "version": "7946.0.14",
+      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.14.tgz",
+      "integrity": "sha512-WCfD5Ht3ZesJUsONdhvm84dmzWOiOzOAqOncN0++w0lBw1o8OuDNJF2McvvCef/yBqb/HYRahp1BYtODFQ8bRg=="
+    },
+    "node_modules/@types/google.maps": {
+      "version": "3.55.7",
+      "resolved": "https://registry.npmjs.org/@types/google.maps/-/google.maps-3.55.7.tgz",
+      "integrity": "sha512-SlWFx0vo7RSAOC63+PTz8FeqLDaRYs7PrS/L0bZSKswxIN5TnCuckbeIwZpgD/S+DWalPteXfDbg5JsUER5Cyw=="
     },
     "node_modules/@types/hammerjs": {
       "version": "2.0.41",
@@ -4138,7 +4356,6 @@
       "version": "20.11.16",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.11.16.tgz",
       "integrity": "sha512-gKb0enTmRCzXSSUJDq6/sPcqrfCv2mkkG6Jt/clpn5eiCbKTY+SgZUxo+p8ZKMof5dCp9vHQUAB7wOUTod22wQ==",
-      "devOptional": true,
       "dependencies": {
         "undici-types": "~5.26.4"
       }
@@ -4152,6 +4369,11 @@
       "version": "2019.7.3",
       "resolved": "https://registry.npmjs.org/@types/offscreencanvas/-/offscreencanvas-2019.7.3.tgz",
       "integrity": "sha512-ieXiYmgSRXUDeOntE1InxjWyvEelZGP63M+cGuquuRLuIKKT1osnkXjxev9B7d1nXSug5vpunx+gNlbVxMlC9A=="
+    },
+    "node_modules/@types/pako": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/@types/pako/-/pako-1.0.7.tgz",
+      "integrity": "sha512-YBtzT2ztNF6R/9+UXj2wTGFnC9NklAnASt3sC0h2m1bbH7G6FyBIkt4AN8ThZpNfxUo1b2iMVO0UawiJymEt8A=="
     },
     "node_modules/@types/prop-types": {
       "version": "15.7.4",
@@ -5465,6 +5687,26 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true
     },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "optional": true
+    },
     "node_modules/boolbase": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
@@ -5491,6 +5733,15 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/brotli": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/brotli/-/brotli-1.3.3.tgz",
+      "integrity": "sha512-oTKjJdShmDuGW94SyyaoQvAjf30dZaHnjJ8uAF+u2/vGJkJbJPJAT1gDiOJP5v1Zb6f9KEyW/1HpuaWIXtGHPg==",
+      "optional": true,
+      "dependencies": {
+        "base64-js": "^1.1.2"
       }
     },
     "node_modules/browserslist": {
@@ -5522,6 +5773,14 @@
       },
       "engines": {
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/buf-compare": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buf-compare/-/buf-compare-1.0.1.tgz",
+      "integrity": "sha512-Bvx4xH00qweepGc43xFvMs5BKASXTbHaHm6+kDYIK9p/4iFwjATQkmPKHQSgJZzKbAymhztRbXUf1Nqhzl73/Q==",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/busboy": {
@@ -5730,6 +5989,18 @@
       "integrity": "sha512-JsPKdmh8ZkmnHxDk55FZ1TqVLvEQTvoByJZRN9jzI0UjxK/QgAmsphz7PGtqgPieQZ/CQcHWXCR7ATDNhGe+YA==",
       "dev": true
     },
+    "node_modules/core-assert": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/core-assert/-/core-assert-0.2.1.tgz",
+      "integrity": "sha512-IG97qShIP+nrJCXMCgkNZgH7jZQ4n8RpPyPeXX++T6avR/KhLhgLiHKoEn5Rc1KjfycSfA9DMa6m+4C4eguHhw==",
+      "dependencies": {
+        "buf-compare": "^1.0.0",
+        "is-error": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/core-js-compat": {
       "version": "3.30.2",
       "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.30.2.tgz",
@@ -5742,6 +6013,11 @@
         "type": "opencollective",
         "url": "https://opencollective.com/core-js"
       }
+    },
+    "node_modules/core-util-is": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ=="
     },
     "node_modules/cosmiconfig": {
       "version": "8.2.0",
@@ -5916,48 +6192,31 @@
       "integrity": "sha512-I7K1Uu0MBPzaFKg4nI5Q7Vs2t+3gWWW648spaF+Rg7pI9ds18Ugn+lvg4SHczUdKlHI5LWBXyqfS8+DufyBsgQ=="
     },
     "node_modules/d3-array": {
-      "version": "2.12.1",
-      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-2.12.1.tgz",
-      "integrity": "sha512-B0ErZK/66mHtEsR1TkPEEkwdy+WDesimkM5gpZr5Dsg54BiTA5RXtYW5qTLIAcekaS9xfZrzBLF/OAkB3Qn1YQ==",
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
       "dependencies": {
-        "internmap": "^1.0.0"
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/d3-color": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-2.0.0.tgz",
-      "integrity": "sha512-SPXi0TSKPD4g9tw0NMZFnR95XVgUZiBH+uUTqQuDu1OsE2zomHU7ho0FISciaPvosimixwHFl3WHLGabv6dDgQ=="
-    },
-    "node_modules/d3-dsv": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/d3-dsv/-/d3-dsv-1.2.0.tgz",
-      "integrity": "sha512-9yVlqvZcSOMhCYzniHE7EVUws7Fa1zgw+/EAV2BxJoG3ME19V6BQFBwI855XQDsxyOuG7NibqRMTtiF/Qup46g==",
-      "dependencies": {
-        "commander": "2",
-        "iconv-lite": "0.4",
-        "rw": "1"
-      },
-      "bin": {
-        "csv2json": "bin/dsv2json",
-        "csv2tsv": "bin/dsv2dsv",
-        "dsv2dsv": "bin/dsv2dsv",
-        "dsv2json": "bin/dsv2json",
-        "json2csv": "bin/json2dsv",
-        "json2dsv": "bin/json2dsv",
-        "json2tsv": "bin/json2dsv",
-        "tsv2csv": "bin/dsv2dsv",
-        "tsv2json": "bin/dsv2json"
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "engines": {
+        "node": ">=12"
       }
     },
-    "node_modules/d3-dsv/node_modules/commander": {
-      "version": "2.20.3",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
-    },
     "node_modules/d3-format": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-2.0.0.tgz",
-      "integrity": "sha512-Ab3S6XuE/Q+flY96HXT0jOXcM4EAClYFnRGY5zsjRGNy6qCYrQsMffs7cV5Q9xejb35zxW5hf/guKw34kvIKsA=="
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.0.tgz",
+      "integrity": "sha512-YyUI6AEuY/Wpt8KWLgZHsIU86atmikuoOmCfommt0LYHiQSPjvX2AcFc38PX0CBpr2RCyZhjex+NS/LPOv6YqA==",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/d3-hexbin": {
       "version": "0.2.2",
@@ -5965,39 +6224,51 @@
       "integrity": "sha512-KS3fUT2ReD4RlGCjvCEm1RgMtp2NFZumdMu4DBzQK8AZv3fXRM6Xm8I4fSU07UXvH4xxg03NwWKWdvxfS/yc4w=="
     },
     "node_modules/d3-interpolate": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-2.0.1.tgz",
-      "integrity": "sha512-c5UhwwTs/yybcmTpAVqwSFl6vrQ8JZJoT5F7xNFK9pymv5C0Ymcc9/LIJHtYIggg/yS9YHw8i8O8tgb9pupjeQ==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
       "dependencies": {
-        "d3-color": "1 - 2"
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/d3-scale": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-3.3.0.tgz",
-      "integrity": "sha512-1JGp44NQCt5d1g+Yy+GeOnZP7xHo0ii8zsQp6PGzd+C1/dl0KGsp9A7Mxwp+1D1o4unbTTxVdU/ZOIEBoeZPbQ==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
       "dependencies": {
-        "d3-array": "^2.3.0",
-        "d3-format": "1 - 2",
-        "d3-interpolate": "1.2.0 - 2",
-        "d3-time": "^2.1.1",
-        "d3-time-format": "2 - 3"
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/d3-time": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-2.1.1.tgz",
-      "integrity": "sha512-/eIQe/eR4kCQwq7yxi7z4c6qEXf2IYGcjoWB5OOQy4Tq9Uv39/947qlDcN2TLkiTzQWzvnsuYPB9TrWaNfipKQ==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
       "dependencies": {
-        "d3-array": "2"
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/d3-time-format": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-3.0.0.tgz",
-      "integrity": "sha512-UXJh6EKsHBTjopVqZBhFysQcoXSv/5yLONZvkQ5Kk3qbwiUYkdX17Xa1PT6U1ZWXGGfB1ey5L8dKMlFq2DO0Ag==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
       "dependencies": {
-        "d3-time": "1 - 2"
+        "d3-time": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/damerau-levenshtein": {
@@ -6038,21 +6309,22 @@
       "integrity": "sha512-VBBaLc1MgL5XpzgIP7ny5Z6Nx3UrRkIViUkPUdtl9aya5amy3De1gsUUSB1g3+3sExYNjCAsAznmukyxCb1GRA=="
     },
     "node_modules/deck.gl": {
-      "version": "8.6.6",
-      "resolved": "https://registry.npmjs.org/deck.gl/-/deck.gl-8.6.6.tgz",
-      "integrity": "sha512-SDkRYLkiKTvUvvcY2QTBvL7sjjHMc7ieUN+6vQPFK7Nin72brf6zRGm7IFz+RSSXVe9MPNtPEMJk0+3DldvAhA==",
+      "version": "9.0.6",
+      "resolved": "https://registry.npmjs.org/deck.gl/-/deck.gl-9.0.6.tgz",
+      "integrity": "sha512-9zKzFUe8cuvUYAuqlY0mpJGiDxZ+pdtEam72Bn1+OV5hJa3SGHVE57ozxdTII8nVoe6UZcadNDG3HmXAapL8hg==",
       "dependencies": {
-        "@deck.gl/aggregation-layers": "8.6.6",
-        "@deck.gl/carto": "8.6.6",
-        "@deck.gl/core": "8.6.6",
-        "@deck.gl/extensions": "8.6.6",
-        "@deck.gl/geo-layers": "8.6.6",
-        "@deck.gl/google-maps": "8.6.6",
-        "@deck.gl/json": "8.6.6",
-        "@deck.gl/layers": "8.6.6",
-        "@deck.gl/mapbox": "8.6.6",
-        "@deck.gl/mesh-layers": "8.6.6",
-        "@deck.gl/react": "8.6.6"
+        "@deck.gl/aggregation-layers": "9.0.6",
+        "@deck.gl/carto": "9.0.6",
+        "@deck.gl/core": "9.0.6",
+        "@deck.gl/extensions": "9.0.6",
+        "@deck.gl/geo-layers": "9.0.6",
+        "@deck.gl/google-maps": "9.0.6",
+        "@deck.gl/json": "9.0.6",
+        "@deck.gl/layers": "9.0.6",
+        "@deck.gl/mapbox": "9.0.6",
+        "@deck.gl/mesh-layers": "9.0.6",
+        "@deck.gl/react": "9.0.6",
+        "@deck.gl/widgets": "9.0.6"
       }
     },
     "node_modules/deep-eql": {
@@ -6107,6 +6379,17 @@
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true
+    },
+    "node_modules/deep-strict-equal": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/deep-strict-equal/-/deep-strict-equal-0.2.0.tgz",
+      "integrity": "sha512-3daSWyvZ/zwJvuMGlzG1O+Ow0YSadGfb3jsh9xoCutv2tWyB9dA4YvR9L9/fSdDZa2dByYQe+TqapSGUrjnkoA==",
+      "dependencies": {
+        "core-assert": "^0.2.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/deepmerge": {
       "version": "4.3.1",
@@ -6276,9 +6559,9 @@
       "dev": true
     },
     "node_modules/draco3d": {
-      "version": "1.5.5",
-      "resolved": "https://registry.npmjs.org/draco3d/-/draco3d-1.5.5.tgz",
-      "integrity": "sha512-JVuNV0EJzD3LBYhGyIXJLeBID/EVtmFO1ZNhAYflTgiMiAJlbhXQmRRda/azjc8MRVMHh0gqGhiqHUo5dIXM8Q=="
+      "version": "1.5.7",
+      "resolved": "https://registry.npmjs.org/draco3d/-/draco3d-1.5.7.tgz",
+      "integrity": "sha512-m6WCKt/erDXcw+70IJXnG7M3awwQPAsZvJGX5zY7beBqpELw6RDGkYVU0W43AFxye4pDZ5i2Lbyc/NNGqwjUVQ=="
     },
     "node_modules/duplexer": {
       "version": "0.1.2",
@@ -7194,9 +7477,9 @@
       }
     },
     "node_modules/expression-eval": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/expression-eval/-/expression-eval-2.1.0.tgz",
-      "integrity": "sha512-FUJO/Akvl/JOWkvlqZaqbkhsEWlCJWDeZG4tzX96UH68D9FeRgYgtb55C2qtqbORC0Q6x5419EDjWu4IT9kQfg==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/expression-eval/-/expression-eval-5.0.1.tgz",
+      "integrity": "sha512-7SL4miKp19lI834/F6y156xlNg+i9Q41tteuGNCq9C06S78f1bm3BXuvf0+QpQxv369Pv/P2R7Hb17hzxLpbDA==",
       "deprecated": "The expression-eval npm package is no longer maintained. The package was originally published as part of a now-completed personal project, and I do not have incentives to continue maintenance.",
       "dependencies": {
         "jsep": "^0.3.0"
@@ -7236,6 +7519,27 @@
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
       "dev": true
     },
+    "node_modules/fast-xml-parser": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.3.6.tgz",
+      "integrity": "sha512-M2SovcRxD4+vC493Uc2GZVcZaj66CCJhWurC4viynVSTvrpErCShNcDz1lAho6n9REQKvL/ll4A4/fw6Y9z8nw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/naturalintelligence"
+        }
+      ],
+      "dependencies": {
+        "strnum": "^1.0.5"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      }
+    },
     "node_modules/fastq": {
       "version": "1.15.0",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.15.0.tgz",
@@ -7244,6 +7548,11 @@
       "dependencies": {
         "reusify": "^1.0.4"
       }
+    },
+    "node_modules/fflate": {
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.7.4.tgz",
+      "integrity": "sha512-5u2V/CDW15QM1XbbgS+0DfPxVB+jUKhWEKuuFuHncbk3tEEqzmoXL+2KyOFuKGqOnmdIy0/davWF1CkuwtibCw=="
     },
     "node_modules/file-entry-cache": {
       "version": "6.0.1",
@@ -7576,9 +7885,9 @@
       }
     },
     "node_modules/h3-js": {
-      "version": "3.7.2",
-      "resolved": "https://registry.npmjs.org/h3-js/-/h3-js-3.7.2.tgz",
-      "integrity": "sha512-LPjlHSwB9zQZrMqKloCZmmmt3yZzIK7nqPcXqwU93zT3TtYG6jP4tZBzAPouxut7lLjdFbMQ75wRBiKfpsnY7w==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/h3-js/-/h3-js-4.1.0.tgz",
+      "integrity": "sha512-LQhmMl1dRQQjMXPzJc7MpZ/CqPOWWuAvVEoVJM9n/s7vHypj+c3Pd5rLQCkAsOgAoAYKbNCsYFE++LF7MvSfCQ==",
       "engines": {
         "node": ">=4",
         "npm": ">=3",
@@ -7790,17 +8099,6 @@
         "node": ">=16.17.0"
       }
     },
-    "node_modules/iconv-lite": {
-      "version": "0.4.24",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
-      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
-      "dependencies": {
-        "safer-buffer": ">= 2.1.2 < 3"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/ieee754": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
@@ -7839,6 +8137,11 @@
       "engines": {
         "node": ">=6.9.0"
       }
+    },
+    "node_modules/immediate": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+      "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ=="
     },
     "node_modules/import-fresh": {
       "version": "3.3.0",
@@ -7899,8 +8202,7 @@
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "dev": true
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
     "node_modules/internal-slot": {
       "version": "1.0.5",
@@ -7917,9 +8219,12 @@
       }
     },
     "node_modules/internmap": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/internmap/-/internmap-1.0.1.tgz",
-      "integrity": "sha512-lDB5YccMydFBtasVtxnZ3MRBHuaoE8GKsppq+EchKL2U4nK/DmEpPHNH8MZe5HkMtpSiTSOZwfN0tzYjO/lJEw=="
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/is-arguments": {
       "version": "1.1.1",
@@ -8043,6 +8348,11 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/is-error": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/is-error/-/is-error-2.2.2.tgz",
+      "integrity": "sha512-IOQqts/aHWbiisY5DuPJQ0gcbvaLFCa7fBa9xoLfxBZvQ+ZI/Zh9xoI7Gk+G64N0FdK4AbibytHht2tWgpJWLg=="
     },
     "node_modules/is-extglob": {
       "version": "2.1.1",
@@ -8292,6 +8602,11 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ=="
+    },
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
@@ -8483,6 +8798,17 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/jszip": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.10.1.tgz",
+      "integrity": "sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==",
+      "dependencies": {
+        "lie": "~3.3.0",
+        "pako": "~1.0.2",
+        "readable-stream": "~2.3.6",
+        "setimmediate": "^1.0.5"
+      }
+    },
     "node_modules/ktx-parse": {
       "version": "0.0.4",
       "resolved": "https://registry.npmjs.org/ktx-parse/-/ktx-parse-0.0.4.tgz",
@@ -8517,6 +8843,14 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/lie": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
+      "integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
+      "dependencies": {
+        "immediate": "~3.0.5"
       }
     },
     "node_modules/lines-and-columns": {
@@ -8622,6 +8956,17 @@
         "lz-string": "bin/bin.js"
       }
     },
+    "node_modules/lz4js": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/lz4js/-/lz4js-0.2.0.tgz",
+      "integrity": "sha512-gY2Ia9Lm7Ep8qMiuGRhvUq0Q7qUereeldZPP1PMEJxPtEWHJLqw9pgX68oHajBH0nzJK4MaZEA/YNV3jT8u8Bg==",
+      "optional": true
+    },
+    "node_modules/lzo-wasm": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/lzo-wasm/-/lzo-wasm-0.0.4.tgz",
+      "integrity": "sha512-VKlnoJRFrB8SdJhlVKvW5vI1gGwcZ+mvChEXcSX6r2xDNc/Q2FD9esfBmGCuPZdrJ1feO+YcVFd2PTk0c137Gw=="
+    },
     "node_modules/magic-string": {
       "version": "0.30.6",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.6.tgz",
@@ -8632,14 +8977,6 @@
       },
       "engines": {
         "node": ">=12"
-      }
-    },
-    "node_modules/math.gl": {
-      "version": "3.6.3",
-      "resolved": "https://registry.npmjs.org/math.gl/-/math.gl-3.6.3.tgz",
-      "integrity": "sha512-Yq9CyECvSDox9+5ETi2+x1bGTY5WvGUGL3rJfC4KPoCZAM51MGfrCm6rIn4yOJUVfMPs2a5RwMD+yGS/n1g3gg==",
-      "dependencies": {
-        "@math.gl/core": "3.6.3"
       }
     },
     "node_modules/md5": {
@@ -8766,6 +9103,25 @@
         "pathe": "^1.1.1",
         "pkg-types": "^1.0.3",
         "ufo": "^1.3.0"
+      }
+    },
+    "node_modules/moment": {
+      "version": "2.30.1",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.30.1.tgz",
+      "integrity": "sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/moment-timezone": {
+      "version": "0.5.45",
+      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.45.tgz",
+      "integrity": "sha512-HIWmqA86KcmCAhnMAN0wuDOARV/525R2+lOLotuGFzn4HO+FH+/645z2wx0Dt3iDv6/p61SIvKnDstISainhLQ==",
+      "dependencies": {
+        "moment": "^2.29.4"
+      },
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/mrmime": {
@@ -9132,6 +9488,11 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/pako": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw=="
+    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -9301,6 +9662,15 @@
       "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ=="
     },
+    "node_modules/preact": {
+      "version": "10.20.2",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.20.2.tgz",
+      "integrity": "sha512-S1d1ernz3KQ+Y2awUxKakpfOg2CEmJmwOP+6igPx6dgr6pgDvenqYviyokWso2rhHvGtTlWWnJDa7RaPbQerTg==",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/preact"
+      }
+    },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -9351,33 +9721,10 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
-    "node_modules/probe.gl": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/probe.gl/-/probe.gl-3.6.0.tgz",
-      "integrity": "sha512-19JydJWI7+DtR4feV+pu4Mn1I5TAc0xojuxVgZdXIyfmTLfUaFnk4OloWK1bKbPtkgGKLr2lnbnCXmpZEcEp9g==",
-      "dependencies": {
-        "@babel/runtime": "^7.0.0",
-        "@probe.gl/env": "3.6.0",
-        "@probe.gl/log": "3.6.0",
-        "@probe.gl/stats": "3.6.0"
-      }
-    },
-    "node_modules/probe.gl/node_modules/@probe.gl/log": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/@probe.gl/log/-/log-3.6.0.tgz",
-      "integrity": "sha512-hjpyenpEvOdowgZ1qMeCJxfRD4JkKdlXz0RC14m42Un62NtOT+GpWyKA4LssT0+xyLULCByRAtG2fzZorpIAcA==",
-      "dependencies": {
-        "@babel/runtime": "^7.0.0",
-        "@probe.gl/env": "3.6.0"
-      }
-    },
-    "node_modules/probe.gl/node_modules/@probe.gl/stats": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/@probe.gl/stats/-/stats-3.6.0.tgz",
-      "integrity": "sha512-JdALQXB44OP4kUBN/UrQgzbJe4qokbVF4Y8lkIA8iVCFnjVowWIgkD/z/0QO65yELT54tTrtepw1jScjKB+rhQ==",
-      "dependencies": {
-        "@babel/runtime": "^7.0.0"
-      }
+    "node_modules/process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
     },
     "node_modules/prop-types": {
       "version": "15.8.1",
@@ -9415,6 +9762,17 @@
       "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/quadbin": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/quadbin/-/quadbin-0.2.0.tgz",
+      "integrity": "sha512-bPgyRreIsFVwKxHRY+GFdaXatNmfQ1LzaQZj7aKEz07/gL893uWREhmRZpG6UuvlGHdTOPw/NGvqLsJica2goA==",
+      "dependencies": {
+        "@mapbox/tile-cover": "3.0.1"
+      },
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/querystringify": {
@@ -9508,6 +9866,20 @@
         "react": ">=15"
       }
     },
+    "node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
     "node_modules/redent": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
@@ -9562,7 +9934,8 @@
     "node_modules/regenerator-runtime": {
       "version": "0.13.4",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.4.tgz",
-      "integrity": "sha512-plpwicqEzfEyTQohIKktWigcLzmNStMGwbOUbykx51/29Z3JOGYldaaNGK7ngNXV+UcoqvIMmloZ48Sr74sd+g=="
+      "integrity": "sha512-plpwicqEzfEyTQohIKktWigcLzmNStMGwbOUbykx51/29Z3JOGYldaaNGK7ngNXV+UcoqvIMmloZ48Sr74sd+g==",
+      "dev": true
     },
     "node_modules/regenerator-transform": {
       "version": "0.15.1",
@@ -9753,11 +10126,6 @@
         "queue-microtask": "^1.2.2"
       }
     },
-    "node_modules/rw": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/rw/-/rw-1.3.3.tgz",
-      "integrity": "sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ=="
-    },
     "node_modules/safe-array-concat": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/safe-array-concat/-/safe-array-concat-1.0.1.tgz",
@@ -9781,6 +10149,11 @@
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
       "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
       "dev": true
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
     },
     "node_modules/safe-regex-test": {
       "version": "1.0.0",
@@ -9842,6 +10215,11 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/setimmediate": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+      "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA=="
     },
     "node_modules/shallowequal": {
       "version": "1.1.0",
@@ -9940,6 +10318,11 @@
       "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
       "dev": true
     },
+    "node_modules/snappyjs": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/snappyjs/-/snappyjs-0.6.1.tgz",
+      "integrity": "sha512-YIK6I2lsH072UE0aOFxxY1dPDCS43I5ktqHpeAsuLNYWkE5pGxRGWfDM4/vSUfNzXjC1Ivzt3qx31PCLmc9yqg=="
+    },
     "node_modules/source-map-js": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.0.tgz",
@@ -9983,6 +10366,14 @@
       "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
       "engines": {
         "node": ">=10.0.0"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
       }
     },
     "node_modules/string.prototype.matchall": {
@@ -10118,6 +10509,11 @@
         "url": "https://github.com/sponsors/antfu"
       }
     },
+    "node_modules/strnum": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.0.5.tgz",
+      "integrity": "sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA=="
+    },
     "node_modules/styled-components": {
       "version": "6.1.8",
       "resolved": "https://registry.npmjs.org/styled-components/-/styled-components-6.1.8.tgz",
@@ -10252,6 +10648,12 @@
       "bin": {
         "texture-compressor": "bin/texture-compressor.js"
       }
+    },
+    "node_modules/tilebelt": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/tilebelt/-/tilebelt-1.0.1.tgz",
+      "integrity": "sha512-cxHzpa5JgsugY9NUVRH43gPaGJw/29LecAn4X7UGOP64+kB8pU4VQ3bIhSyfb5Mk4jDxwl3yk330L/EIhbJ5aw==",
+      "deprecated": "This module is now under the @mapbox namespace: install @mapbox/tilebelt instead"
     },
     "node_modules/tinybench": {
       "version": "2.5.1",
@@ -10536,8 +10938,7 @@
     "node_modules/undici-types": {
       "version": "5.26.5",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
-      "devOptional": true
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="
     },
     "node_modules/unicode-canonical-property-names-ecmascript": {
       "version": "2.0.0",
@@ -10633,6 +11034,11 @@
         "querystringify": "^2.1.1",
         "requires-port": "^1.0.0"
       }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
     },
     "node_modules/vite": {
       "version": "5.2.8",
@@ -11138,6 +11544,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/zstd-codec": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/zstd-codec/-/zstd-codec-0.1.4.tgz",
+      "integrity": "sha512-KYnWoFWgGtWyQEKNnUcb3u8ZtKO8dn5d8u+oGpxPlopqsPyv60U8suDyfk7Z7UtAO6Sk5i1aVcAs9RbaB1n36A==",
+      "optional": true
     }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -2161,10 +2161,25 @@
       "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.8.0.tgz",
       "integrity": "sha512-VINS5vEYAscRl2ZUDiT3uMPlrFQupiKgHz5AA4bCH1miKBg4qtwkim1qPmJj/4WG6TreYMY111rEFsjupcOKHw=="
     },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.20.2.tgz",
+      "integrity": "sha512-D+EBOJHXdNZcLJRBkhENNG8Wji2kgc9AZ9KiPr1JuZjsNtyHzrsfLRrY0tk2H2aoFu6RANO1y1iPPUCDYWkb5g==",
+      "cpu": [
+        "ppc64"
+      ],
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/@esbuild/android-arm": {
-      "version": "0.19.9",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.19.9.tgz",
-      "integrity": "sha512-jkYjjq7SdsWuNI6b5quymW0oC83NN5FdRPuCbs9HZ02mfVdAP8B8eeqLSYU3gb6OJEaY5CQabtTFbqBf26H3GA==",
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.20.2.tgz",
+      "integrity": "sha512-t98Ra6pw2VaDhqNWO2Oph2LXbz/EJcnLmKLGBJwEwXX/JAN83Fym1rU8l0JUWK6HkIbWONCSSatf4sf2NBRx/w==",
       "cpu": [
         "arm"
       ],
@@ -2177,9 +2192,9 @@
       }
     },
     "node_modules/@esbuild/android-arm64": {
-      "version": "0.19.9",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.19.9.tgz",
-      "integrity": "sha512-q4cR+6ZD0938R19MyEW3jEsMzbb/1rulLXiNAJQADD/XYp7pT+rOS5JGxvpRW8dFDEfjW4wLgC/3FXIw4zYglQ==",
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.20.2.tgz",
+      "integrity": "sha512-mRzjLacRtl/tWU0SvD8lUEwb61yP9cqQo6noDZP/O8VkwafSYwZ4yWy24kan8jE/IMERpYncRt2dw438LP3Xmg==",
       "cpu": [
         "arm64"
       ],
@@ -2192,9 +2207,9 @@
       }
     },
     "node_modules/@esbuild/android-x64": {
-      "version": "0.19.9",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.19.9.tgz",
-      "integrity": "sha512-KOqoPntWAH6ZxDwx1D6mRntIgZh9KodzgNOy5Ebt9ghzffOk9X2c1sPwtM9P+0eXbefnDhqYfkh5PLP5ULtWFA==",
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.20.2.tgz",
+      "integrity": "sha512-btzExgV+/lMGDDa194CcUQm53ncxzeBrWJcncOBxuC6ndBkKxnHdFJn86mCIgTELsooUmwUm9FkhSp5HYu00Rg==",
       "cpu": [
         "x64"
       ],
@@ -2207,9 +2222,9 @@
       }
     },
     "node_modules/@esbuild/darwin-arm64": {
-      "version": "0.19.9",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.19.9.tgz",
-      "integrity": "sha512-KBJ9S0AFyLVx2E5D8W0vExqRW01WqRtczUZ8NRu+Pi+87opZn5tL4Y0xT0mA4FtHctd0ZgwNoN639fUUGlNIWw==",
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.20.2.tgz",
+      "integrity": "sha512-4J6IRT+10J3aJH3l1yzEg9y3wkTDgDk7TSDFX+wKFiWjqWp/iCfLIYzGyasx9l0SAFPT1HwSCR+0w/h1ES/MjA==",
       "cpu": [
         "arm64"
       ],
@@ -2222,9 +2237,9 @@
       }
     },
     "node_modules/@esbuild/darwin-x64": {
-      "version": "0.19.9",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.19.9.tgz",
-      "integrity": "sha512-vE0VotmNTQaTdX0Q9dOHmMTao6ObjyPm58CHZr1UK7qpNleQyxlFlNCaHsHx6Uqv86VgPmR4o2wdNq3dP1qyDQ==",
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.20.2.tgz",
+      "integrity": "sha512-tBcXp9KNphnNH0dfhv8KYkZhjc+H3XBkF5DKtswJblV7KlT9EI2+jeA8DgBjp908WEuYll6pF+UStUCfEpdysA==",
       "cpu": [
         "x64"
       ],
@@ -2237,9 +2252,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.19.9",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.19.9.tgz",
-      "integrity": "sha512-uFQyd/o1IjiEk3rUHSwUKkqZwqdvuD8GevWF065eqgYfexcVkxh+IJgwTaGZVu59XczZGcN/YMh9uF1fWD8j1g==",
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.20.2.tgz",
+      "integrity": "sha512-d3qI41G4SuLiCGCFGUrKsSeTXyWG6yem1KcGZVS+3FYlYhtNoNgYrWcvkOoaqMhwXSMrZRl69ArHsGJ9mYdbbw==",
       "cpu": [
         "arm64"
       ],
@@ -2252,9 +2267,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-x64": {
-      "version": "0.19.9",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.19.9.tgz",
-      "integrity": "sha512-WMLgWAtkdTbTu1AWacY7uoj/YtHthgqrqhf1OaEWnZb7PQgpt8eaA/F3LkV0E6K/Lc0cUr/uaVP/49iE4M4asA==",
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.20.2.tgz",
+      "integrity": "sha512-d+DipyvHRuqEeM5zDivKV1KuXn9WeRX6vqSqIDgwIfPQtwMP4jaDsQsDncjTDDsExT4lR/91OLjRo8bmC1e+Cw==",
       "cpu": [
         "x64"
       ],
@@ -2267,9 +2282,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm": {
-      "version": "0.19.9",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.19.9.tgz",
-      "integrity": "sha512-C/ChPohUYoyUaqn1h17m/6yt6OB14hbXvT8EgM1ZWaiiTYz7nWZR0SYmMnB5BzQA4GXl3BgBO1l8MYqL/He3qw==",
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.20.2.tgz",
+      "integrity": "sha512-VhLPeR8HTMPccbuWWcEUD1Az68TqaTYyj6nfE4QByZIQEQVWBB8vup8PpR7y1QHL3CpcF6xd5WVBU/+SBEvGTg==",
       "cpu": [
         "arm"
       ],
@@ -2282,9 +2297,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm64": {
-      "version": "0.19.9",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.19.9.tgz",
-      "integrity": "sha512-PiPblfe1BjK7WDAKR1Cr9O7VVPqVNpwFcPWgfn4xu0eMemzRp442hXyzF/fSwgrufI66FpHOEJk0yYdPInsmyQ==",
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.20.2.tgz",
+      "integrity": "sha512-9pb6rBjGvTFNira2FLIWqDk/uaf42sSyLE8j1rnUpuzsODBq7FvpwHYZxQ/It/8b+QOS1RYfqgGFNLRI+qlq2A==",
       "cpu": [
         "arm64"
       ],
@@ -2297,9 +2312,9 @@
       }
     },
     "node_modules/@esbuild/linux-ia32": {
-      "version": "0.19.9",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.19.9.tgz",
-      "integrity": "sha512-f37i/0zE0MjDxijkPSQw1CO/7C27Eojqb+r3BbHVxMLkj8GCa78TrBZzvPyA/FNLUMzP3eyHCVkAopkKVja+6Q==",
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.20.2.tgz",
+      "integrity": "sha512-o10utieEkNPFDZFQm9CoP7Tvb33UutoJqg3qKf1PWVeeJhJw0Q347PxMvBgVVFgouYLGIhFYG0UGdBumROyiig==",
       "cpu": [
         "ia32"
       ],
@@ -2312,9 +2327,9 @@
       }
     },
     "node_modules/@esbuild/linux-loong64": {
-      "version": "0.19.9",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.19.9.tgz",
-      "integrity": "sha512-t6mN147pUIf3t6wUt3FeumoOTPfmv9Cc6DQlsVBpB7eCpLOqQDyWBP1ymXn1lDw4fNUSb/gBcKAmvTP49oIkaA==",
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.20.2.tgz",
+      "integrity": "sha512-PR7sp6R/UC4CFVomVINKJ80pMFlfDfMQMYynX7t1tNTeivQ6XdX5r2XovMmha/VjR1YN/HgHWsVcTRIMkymrgQ==",
       "cpu": [
         "loong64"
       ],
@@ -2327,9 +2342,9 @@
       }
     },
     "node_modules/@esbuild/linux-mips64el": {
-      "version": "0.19.9",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.19.9.tgz",
-      "integrity": "sha512-jg9fujJTNTQBuDXdmAg1eeJUL4Jds7BklOTkkH80ZgQIoCTdQrDaHYgbFZyeTq8zbY+axgptncko3v9p5hLZtw==",
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.20.2.tgz",
+      "integrity": "sha512-4BlTqeutE/KnOiTG5Y6Sb/Hw6hsBOZapOVF6njAESHInhlQAghVVZL1ZpIctBOoTFbQyGW+LsVYZ8lSSB3wkjA==",
       "cpu": [
         "mips64el"
       ],
@@ -2342,9 +2357,9 @@
       }
     },
     "node_modules/@esbuild/linux-ppc64": {
-      "version": "0.19.9",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.19.9.tgz",
-      "integrity": "sha512-tkV0xUX0pUUgY4ha7z5BbDS85uI7ABw3V1d0RNTii7E9lbmV8Z37Pup2tsLV46SQWzjOeyDi1Q7Wx2+QM8WaCQ==",
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.20.2.tgz",
+      "integrity": "sha512-rD3KsaDprDcfajSKdn25ooz5J5/fWBylaaXkuotBDGnMnDP1Uv5DLAN/45qfnf3JDYyJv/ytGHQaziHUdyzaAg==",
       "cpu": [
         "ppc64"
       ],
@@ -2357,9 +2372,9 @@
       }
     },
     "node_modules/@esbuild/linux-riscv64": {
-      "version": "0.19.9",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.19.9.tgz",
-      "integrity": "sha512-DfLp8dj91cufgPZDXr9p3FoR++m3ZJ6uIXsXrIvJdOjXVREtXuQCjfMfvmc3LScAVmLjcfloyVtpn43D56JFHg==",
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.20.2.tgz",
+      "integrity": "sha512-snwmBKacKmwTMmhLlz/3aH1Q9T8v45bKYGE3j26TsaOVtjIag4wLfWSiZykXzXuE1kbCE+zJRmwp+ZbIHinnVg==",
       "cpu": [
         "riscv64"
       ],
@@ -2372,9 +2387,9 @@
       }
     },
     "node_modules/@esbuild/linux-s390x": {
-      "version": "0.19.9",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.19.9.tgz",
-      "integrity": "sha512-zHbglfEdC88KMgCWpOl/zc6dDYJvWGLiUtmPRsr1OgCViu3z5GncvNVdf+6/56O2Ca8jUU+t1BW261V6kp8qdw==",
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.20.2.tgz",
+      "integrity": "sha512-wcWISOobRWNm3cezm5HOZcYz1sKoHLd8VL1dl309DiixxVFoFe/o8HnwuIwn6sXre88Nwj+VwZUvJf4AFxkyrQ==",
       "cpu": [
         "s390x"
       ],
@@ -2387,9 +2402,9 @@
       }
     },
     "node_modules/@esbuild/linux-x64": {
-      "version": "0.19.9",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.19.9.tgz",
-      "integrity": "sha512-JUjpystGFFmNrEHQnIVG8hKwvA2DN5o7RqiO1CVX8EN/F/gkCjkUMgVn6hzScpwnJtl2mPR6I9XV1oW8k9O+0A==",
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.20.2.tgz",
+      "integrity": "sha512-1MdwI6OOTsfQfek8sLwgyjOXAu+wKhLEoaOLTjbijk6E2WONYpH9ZU2mNtR+lZ2B4uwr+usqGuVfFT9tMtGvGw==",
       "cpu": [
         "x64"
       ],
@@ -2402,9 +2417,9 @@
       }
     },
     "node_modules/@esbuild/netbsd-x64": {
-      "version": "0.19.9",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.19.9.tgz",
-      "integrity": "sha512-GThgZPAwOBOsheA2RUlW5UeroRfESwMq/guy8uEe3wJlAOjpOXuSevLRd70NZ37ZrpO6RHGHgEHvPg1h3S1Jug==",
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.20.2.tgz",
+      "integrity": "sha512-K8/DhBxcVQkzYc43yJXDSyjlFeHQJBiowJ0uVL6Tor3jGQfSGHNNJcWxNbOI8v5k82prYqzPuwkzHt3J1T1iZQ==",
       "cpu": [
         "x64"
       ],
@@ -2417,9 +2432,9 @@
       }
     },
     "node_modules/@esbuild/openbsd-x64": {
-      "version": "0.19.9",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.19.9.tgz",
-      "integrity": "sha512-Ki6PlzppaFVbLnD8PtlVQfsYw4S9n3eQl87cqgeIw+O3sRr9IghpfSKY62mggdt1yCSZ8QWvTZ9jo9fjDSg9uw==",
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.20.2.tgz",
+      "integrity": "sha512-eMpKlV0SThJmmJgiVyN9jTPJ2VBPquf6Kt/nAoo6DgHAoN57K15ZghiHaMvqjCye/uU4X5u3YSMgVBI1h3vKrQ==",
       "cpu": [
         "x64"
       ],
@@ -2432,9 +2447,9 @@
       }
     },
     "node_modules/@esbuild/sunos-x64": {
-      "version": "0.19.9",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.19.9.tgz",
-      "integrity": "sha512-MLHj7k9hWh4y1ddkBpvRj2b9NCBhfgBt3VpWbHQnXRedVun/hC7sIyTGDGTfsGuXo4ebik2+3ShjcPbhtFwWDw==",
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.20.2.tgz",
+      "integrity": "sha512-2UyFtRC6cXLyejf/YEld4Hajo7UHILetzE1vsRcGL3earZEW77JxrFjH4Ez2qaTiEfMgAXxfAZCm1fvM/G/o8w==",
       "cpu": [
         "x64"
       ],
@@ -2447,9 +2462,9 @@
       }
     },
     "node_modules/@esbuild/win32-arm64": {
-      "version": "0.19.9",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.19.9.tgz",
-      "integrity": "sha512-GQoa6OrQ8G08guMFgeXPH7yE/8Dt0IfOGWJSfSH4uafwdC7rWwrfE6P9N8AtPGIjUzdo2+7bN8Xo3qC578olhg==",
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.20.2.tgz",
+      "integrity": "sha512-GRibxoawM9ZCnDxnP3usoUDO9vUkpAxIIZ6GQI+IlVmr5kP3zUq+l17xELTHMWTWzjxa2guPNyrpq1GWmPvcGQ==",
       "cpu": [
         "arm64"
       ],
@@ -2462,9 +2477,9 @@
       }
     },
     "node_modules/@esbuild/win32-ia32": {
-      "version": "0.19.9",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.19.9.tgz",
-      "integrity": "sha512-UOozV7Ntykvr5tSOlGCrqU3NBr3d8JqPes0QWN2WOXfvkWVGRajC+Ym0/Wj88fUgecUCLDdJPDF0Nna2UK3Qtg==",
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.20.2.tgz",
+      "integrity": "sha512-HfLOfn9YWmkSKRQqovpnITazdtquEW8/SoHW7pWpuEeguaZI4QnCRW6b+oZTztdBnZOS2hqJ6im/D5cPzBTTlQ==",
       "cpu": [
         "ia32"
       ],
@@ -2477,9 +2492,9 @@
       }
     },
     "node_modules/@esbuild/win32-x64": {
-      "version": "0.19.9",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.19.9.tgz",
-      "integrity": "sha512-oxoQgglOP7RH6iasDrhY+R/3cHrfwIDvRlT4CGChflq6twk8iENeVvMJjmvBb94Ik1Z+93iGO27err7w6l54GQ==",
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.20.2.tgz",
+      "integrity": "sha512-N49X4lJX27+l9jbLKSqZ6bKNjzQvHaT8IIFUy+YIqmXQdjYCToGWwOItDrfby14c78aDd5NHQl29xingXfCdLQ==",
       "cpu": [
         "x64"
       ],
@@ -3292,9 +3307,9 @@
       }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
-      "version": "4.9.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.9.0.tgz",
-      "integrity": "sha512-+1ge/xmaJpm1KVBuIH38Z94zj9fBD+hp+/5WLaHgyY8XLq1ibxk/zj6dTXaqM2cAbYKq8jYlhHd6k05If1W5xA==",
+      "version": "4.14.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.14.1.tgz",
+      "integrity": "sha512-fH8/o8nSUek8ceQnT7K4EQbSiV7jgkHq81m9lWZFIXjJ7lJzpWXbQFpT/Zh6OZYnpFykvzC3fbEvEAFZu03dPA==",
       "cpu": [
         "arm"
       ],
@@ -3304,9 +3319,9 @@
       ]
     },
     "node_modules/@rollup/rollup-android-arm64": {
-      "version": "4.9.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.9.0.tgz",
-      "integrity": "sha512-im6hUEyQ7ZfoZdNvtwgEJvBWZYauC9KVKq1w58LG2Zfz6zMd8gRrbN+xCVoqA2hv/v6fm9lp5LFGJ3za8EQH3A==",
+      "version": "4.14.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.14.1.tgz",
+      "integrity": "sha512-Y/9OHLjzkunF+KGEoJr3heiD5X9OLa8sbT1lm0NYeKyaM3oMhhQFvPB0bNZYJwlq93j8Z6wSxh9+cyKQaxS7PQ==",
       "cpu": [
         "arm64"
       ],
@@ -3316,9 +3331,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-arm64": {
-      "version": "4.9.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.9.0.tgz",
-      "integrity": "sha512-u7aTMskN6Dmg1lCT0QJ+tINRt+ntUrvVkhbPfFz4bCwRZvjItx2nJtwJnJRlKMMaQCHRjrNqHRDYvE4mBm3DlQ==",
+      "version": "4.14.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.14.1.tgz",
+      "integrity": "sha512-+kecg3FY84WadgcuSVm6llrABOdQAEbNdnpi5X3UwWiFVhZIZvKgGrF7kmLguvxHNQy+UuRV66cLVl3S+Rkt+Q==",
       "cpu": [
         "arm64"
       ],
@@ -3328,9 +3343,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-x64": {
-      "version": "4.9.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.9.0.tgz",
-      "integrity": "sha512-8FvEl3w2ExmpcOmX5RJD0yqXcVSOqAJJUJ29Lca29Ik+3zPS1yFimr2fr5JSZ4Z5gt8/d7WqycpgkX9nocijSw==",
+      "version": "4.14.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.14.1.tgz",
+      "integrity": "sha512-2pYRzEjVqq2TB/UNv47BV/8vQiXkFGVmPFwJb+1E0IFFZbIX8/jo1olxqqMbo6xCXf8kabANhp5bzCij2tFLUA==",
       "cpu": [
         "x64"
       ],
@@ -3340,9 +3355,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-      "version": "4.9.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.9.0.tgz",
-      "integrity": "sha512-lHoKYaRwd4gge+IpqJHCY+8Vc3hhdJfU6ukFnnrJasEBUvVlydP8PuwndbWfGkdgSvZhHfSEw6urrlBj0TSSfg==",
+      "version": "4.14.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.14.1.tgz",
+      "integrity": "sha512-mS6wQ6Do6/wmrF9aTFVpIJ3/IDXhg1EZcQFYHZLHqw6AzMBjTHWnCG35HxSqUNphh0EHqSM6wRTT8HsL1C0x5g==",
       "cpu": [
         "arm"
       ],
@@ -3352,9 +3367,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-gnu": {
-      "version": "4.9.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.9.0.tgz",
-      "integrity": "sha512-JbEPfhndYeWHfOSeh4DOFvNXrj7ls9S/2omijVsao+LBPTPayT1uKcK3dHW3MwDJ7KO11t9m2cVTqXnTKpeaiw==",
+      "version": "4.14.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.14.1.tgz",
+      "integrity": "sha512-p9rGKYkHdFMzhckOTFubfxgyIO1vw//7IIjBBRVzyZebWlzRLeNhqxuSaZ7kCEKVkm/kuC9fVRW9HkC/zNRG2w==",
       "cpu": [
         "arm64"
       ],
@@ -3364,9 +3379,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-musl": {
-      "version": "4.9.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.9.0.tgz",
-      "integrity": "sha512-ahqcSXLlcV2XUBM3/f/C6cRoh7NxYA/W7Yzuv4bDU1YscTFw7ay4LmD7l6OS8EMhTNvcrWGkEettL1Bhjf+B+w==",
+      "version": "4.14.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.14.1.tgz",
+      "integrity": "sha512-nDY6Yz5xS/Y4M2i9JLQd3Rofh5OR8Bn8qe3Mv/qCVpHFlwtZSBYSPaU4mrGazWkXrdQ98GB//H0BirGR/SKFSw==",
       "cpu": [
         "arm64"
       ],
@@ -3375,10 +3390,22 @@
         "linux"
       ]
     },
+    "node_modules/@rollup/rollup-linux-powerpc64le-gnu": {
+      "version": "4.14.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.14.1.tgz",
+      "integrity": "sha512-im7HE4VBL+aDswvcmfx88Mp1soqL9OBsdDBU8NqDEYtkri0qV0THhQsvZtZeNNlLeCUQ16PZyv7cqutjDF35qw==",
+      "cpu": [
+        "ppc64le"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
     "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-      "version": "4.9.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.9.0.tgz",
-      "integrity": "sha512-uwvOYNtLw8gVtrExKhdFsYHA/kotURUmZYlinH2VcQxNCQJeJXnkmWgw2hI9Xgzhgu7J9QvWiq9TtTVwWMDa+w==",
+      "version": "4.14.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.14.1.tgz",
+      "integrity": "sha512-RWdiHuAxWmzPJgaHJdpvUUlDz8sdQz4P2uv367T2JocdDa98iRw2UjIJ4QxSyt077mXZT2X6pKfT2iYtVEvOFw==",
       "cpu": [
         "riscv64"
       ],
@@ -3387,10 +3414,22 @@
         "linux"
       ]
     },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.14.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.14.1.tgz",
+      "integrity": "sha512-VMgaGQ5zRX6ZqV/fas65/sUGc9cPmsntq2FiGmayW9KMNfWVG/j0BAqImvU4KTeOOgYSf1F+k6at1UfNONuNjA==",
+      "cpu": [
+        "s390x"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.9.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.9.0.tgz",
-      "integrity": "sha512-m6pkSwcZZD2LCFHZX/zW2aLIISyzWLU3hrLLzQKMI12+OLEzgruTovAxY5sCZJkipklaZqPy/2bEEBNjp+Y7xg==",
+      "version": "4.14.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.14.1.tgz",
+      "integrity": "sha512-9Q7DGjZN+hTdJomaQ3Iub4m6VPu1r94bmK2z3UeWP3dGUecRC54tmVu9vKHTm1bOt3ASoYtEz6JSRLFzrysKlA==",
       "cpu": [
         "x64"
       ],
@@ -3400,9 +3439,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-musl": {
-      "version": "4.9.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.9.0.tgz",
-      "integrity": "sha512-VFAC1RDRSbU3iOF98X42KaVicAfKf0m0OvIu8dbnqhTe26Kh6Ym9JrDulz7Hbk7/9zGc41JkV02g+p3BivOdAg==",
+      "version": "4.14.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.14.1.tgz",
+      "integrity": "sha512-JNEG/Ti55413SsreTguSx0LOVKX902OfXIKVg+TCXO6Gjans/k9O6ww9q3oLGjNDaTLxM+IHFMeXy/0RXL5R/g==",
       "cpu": [
         "x64"
       ],
@@ -3412,9 +3451,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-arm64-msvc": {
-      "version": "4.9.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.9.0.tgz",
-      "integrity": "sha512-9jPgMvTKXARz4inw6jezMLA2ihDBvgIU9Ml01hjdVpOcMKyxFBJrn83KVQINnbeqDv0+HdO1c09hgZ8N0s820Q==",
+      "version": "4.14.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.14.1.tgz",
+      "integrity": "sha512-ryS22I9y0mumlLNwDFYZRDFLwWh3aKaC72CWjFcFvxK0U6v/mOkM5Up1bTbCRAhv3kEIwW2ajROegCIQViUCeA==",
       "cpu": [
         "arm64"
       ],
@@ -3424,9 +3463,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-ia32-msvc": {
-      "version": "4.9.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.9.0.tgz",
-      "integrity": "sha512-WE4pT2kTXQN2bAv40Uog0AsV7/s9nT9HBWXAou8+++MBCnY51QS02KYtm6dQxxosKi1VIz/wZIrTQO5UP2EW+Q==",
+      "version": "4.14.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.14.1.tgz",
+      "integrity": "sha512-TdloItiGk+T0mTxKx7Hp279xy30LspMso+GzQvV2maYePMAWdmrzqSNZhUpPj3CGw12aGj57I026PgLCTu8CGg==",
       "cpu": [
         "ia32"
       ],
@@ -3436,9 +3475,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-x64-msvc": {
-      "version": "4.9.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.9.0.tgz",
-      "integrity": "sha512-aPP5Q5AqNGuT0tnuEkK/g4mnt3ZhheiXrDIiSVIHN9mcN21OyXDVbEMqmXPE7e2OplNLDkcvV+ZoGJa2ZImFgw==",
+      "version": "4.14.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.14.1.tgz",
+      "integrity": "sha512-wQGI+LY/Py20zdUPq+XCem7JcPOyzIJBm3dli+56DJsQOHbnXZFEwgmnC6el1TPAfC8lBT3m+z69RmLykNUbew==",
       "cpu": [
         "x64"
       ],
@@ -4056,8 +4095,7 @@
     "node_modules/@types/estree": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.5.tgz",
-      "integrity": "sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==",
-      "dev": true
+      "integrity": "sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw=="
     },
     "node_modules/@types/geojson": {
       "version": "7946.0.13",
@@ -4856,9 +4894,9 @@
       }
     },
     "node_modules/@typescript-eslint/utils/node_modules/semver": {
-      "version": "7.5.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.1.tgz",
-      "integrity": "sha512-Wvss5ivl8TMRZXXESstBA4uR5iXgEN/VC5/sOcuXdVLzcdkz4HWetIoRfG5gb5X+ij/G9rw9YoGn3QoQ8OCSpw==",
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
+      "integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
       "dev": true,
       "dependencies": {
         "lru-cache": "^6.0.0"
@@ -6426,9 +6464,9 @@
       }
     },
     "node_modules/esbuild": {
-      "version": "0.19.9",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.19.9.tgz",
-      "integrity": "sha512-U9CHtKSy+EpPsEBa+/A2gMs/h3ylBC0H0KSqIg7tpztHerLi6nrrcoUJAkNCEPumx8yJ+Byic4BVwHgRbN0TBg==",
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.20.2.tgz",
+      "integrity": "sha512-WdOOppmUNU+IbZ0PaDiTst80zjnrOkyJNHoKupIcVyU8Lvla3Ugx94VzkQ32Ijqd7UhHJy75gNWDMUekcrSJ6g==",
       "hasInstallScript": true,
       "bin": {
         "esbuild": "bin/esbuild"
@@ -6437,28 +6475,29 @@
         "node": ">=12"
       },
       "optionalDependencies": {
-        "@esbuild/android-arm": "0.19.9",
-        "@esbuild/android-arm64": "0.19.9",
-        "@esbuild/android-x64": "0.19.9",
-        "@esbuild/darwin-arm64": "0.19.9",
-        "@esbuild/darwin-x64": "0.19.9",
-        "@esbuild/freebsd-arm64": "0.19.9",
-        "@esbuild/freebsd-x64": "0.19.9",
-        "@esbuild/linux-arm": "0.19.9",
-        "@esbuild/linux-arm64": "0.19.9",
-        "@esbuild/linux-ia32": "0.19.9",
-        "@esbuild/linux-loong64": "0.19.9",
-        "@esbuild/linux-mips64el": "0.19.9",
-        "@esbuild/linux-ppc64": "0.19.9",
-        "@esbuild/linux-riscv64": "0.19.9",
-        "@esbuild/linux-s390x": "0.19.9",
-        "@esbuild/linux-x64": "0.19.9",
-        "@esbuild/netbsd-x64": "0.19.9",
-        "@esbuild/openbsd-x64": "0.19.9",
-        "@esbuild/sunos-x64": "0.19.9",
-        "@esbuild/win32-arm64": "0.19.9",
-        "@esbuild/win32-ia32": "0.19.9",
-        "@esbuild/win32-x64": "0.19.9"
+        "@esbuild/aix-ppc64": "0.20.2",
+        "@esbuild/android-arm": "0.20.2",
+        "@esbuild/android-arm64": "0.20.2",
+        "@esbuild/android-x64": "0.20.2",
+        "@esbuild/darwin-arm64": "0.20.2",
+        "@esbuild/darwin-x64": "0.20.2",
+        "@esbuild/freebsd-arm64": "0.20.2",
+        "@esbuild/freebsd-x64": "0.20.2",
+        "@esbuild/linux-arm": "0.20.2",
+        "@esbuild/linux-arm64": "0.20.2",
+        "@esbuild/linux-ia32": "0.20.2",
+        "@esbuild/linux-loong64": "0.20.2",
+        "@esbuild/linux-mips64el": "0.20.2",
+        "@esbuild/linux-ppc64": "0.20.2",
+        "@esbuild/linux-riscv64": "0.20.2",
+        "@esbuild/linux-s390x": "0.20.2",
+        "@esbuild/linux-x64": "0.20.2",
+        "@esbuild/netbsd-x64": "0.20.2",
+        "@esbuild/openbsd-x64": "0.20.2",
+        "@esbuild/sunos-x64": "0.20.2",
+        "@esbuild/win32-arm64": "0.20.2",
+        "@esbuild/win32-ia32": "0.20.2",
+        "@esbuild/win32-x64": "0.20.2"
       }
     },
     "node_modules/escalade": {
@@ -7250,9 +7289,9 @@
       "dev": true
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.5",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.5.tgz",
-      "integrity": "sha512-vSFWUON1B+yAw1VN4xMfxgn5fTUiaOzAJCKBwIIgT/+7CuGy9+r+5gITvP62j3RmaD5Ph65UaERdOSRGUzZtgw==",
+      "version": "1.15.6",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.6.tgz",
+      "integrity": "sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA==",
       "funding": [
         {
           "type": "individual",
@@ -9654,9 +9693,12 @@
       }
     },
     "node_modules/rollup": {
-      "version": "4.9.0",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.9.0.tgz",
-      "integrity": "sha512-bUHW/9N21z64gw8s6tP4c88P382Bq/L5uZDowHlHx6s/QWpjJXivIAbEw6LZthgSvlEizZBfLC4OAvWe7aoF7A==",
+      "version": "4.14.1",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.14.1.tgz",
+      "integrity": "sha512-4LnHSdd3QK2pa1J6dFbfm1HN0D7vSK/ZuZTsdyUAlA6Rr1yTouUTL13HaDOGJVgby461AhrNGBS7sCGXXtT+SA==",
+      "dependencies": {
+        "@types/estree": "1.0.5"
+      },
       "bin": {
         "rollup": "dist/bin/rollup"
       },
@@ -9665,19 +9707,21 @@
         "npm": ">=8.0.0"
       },
       "optionalDependencies": {
-        "@rollup/rollup-android-arm-eabi": "4.9.0",
-        "@rollup/rollup-android-arm64": "4.9.0",
-        "@rollup/rollup-darwin-arm64": "4.9.0",
-        "@rollup/rollup-darwin-x64": "4.9.0",
-        "@rollup/rollup-linux-arm-gnueabihf": "4.9.0",
-        "@rollup/rollup-linux-arm64-gnu": "4.9.0",
-        "@rollup/rollup-linux-arm64-musl": "4.9.0",
-        "@rollup/rollup-linux-riscv64-gnu": "4.9.0",
-        "@rollup/rollup-linux-x64-gnu": "4.9.0",
-        "@rollup/rollup-linux-x64-musl": "4.9.0",
-        "@rollup/rollup-win32-arm64-msvc": "4.9.0",
-        "@rollup/rollup-win32-ia32-msvc": "4.9.0",
-        "@rollup/rollup-win32-x64-msvc": "4.9.0",
+        "@rollup/rollup-android-arm-eabi": "4.14.1",
+        "@rollup/rollup-android-arm64": "4.14.1",
+        "@rollup/rollup-darwin-arm64": "4.14.1",
+        "@rollup/rollup-darwin-x64": "4.14.1",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.14.1",
+        "@rollup/rollup-linux-arm64-gnu": "4.14.1",
+        "@rollup/rollup-linux-arm64-musl": "4.14.1",
+        "@rollup/rollup-linux-powerpc64le-gnu": "4.14.1",
+        "@rollup/rollup-linux-riscv64-gnu": "4.14.1",
+        "@rollup/rollup-linux-s390x-gnu": "4.14.1",
+        "@rollup/rollup-linux-x64-gnu": "4.14.1",
+        "@rollup/rollup-linux-x64-musl": "4.14.1",
+        "@rollup/rollup-win32-arm64-msvc": "4.14.1",
+        "@rollup/rollup-win32-ia32-msvc": "4.14.1",
+        "@rollup/rollup-win32-x64-msvc": "4.14.1",
         "fsevents": "~2.3.2"
       }
     },
@@ -9897,9 +9941,9 @@
       "dev": true
     },
     "node_modules/source-map-js": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
-      "integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.0.tgz",
+      "integrity": "sha512-itJW8lvSA0TXEphiRoawsCksnlf8SyvmFzIhltqAHluXd88pkCd+cXJVHTDwdCr0IzwptSm035IHQktUu1QUMg==",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -10591,13 +10635,13 @@
       }
     },
     "node_modules/vite": {
-      "version": "5.0.12",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-5.0.12.tgz",
-      "integrity": "sha512-4hsnEkG3q0N4Tzf1+t6NdN9dg/L3BM+q8SWgbSPnJvrgH2kgdyzfVJwbR1ic69/4uMJJ/3dqDZZE5/WwqW8U1w==",
+      "version": "5.2.8",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.2.8.tgz",
+      "integrity": "sha512-OyZR+c1CE8yeHw5V5t59aXsUPPVTHMDjEZz8MgguLL/Q7NblxhZUlTu9xSPqlsUO/y+X7dlU05jdhvyycD55DA==",
       "dependencies": {
-        "esbuild": "^0.19.3",
-        "postcss": "^8.4.32",
-        "rollup": "^4.2.0"
+        "esbuild": "^0.20.1",
+        "postcss": "^8.4.38",
+        "rollup": "^4.13.0"
       },
       "bin": {
         "vite": "bin/vite.js"
@@ -10690,9 +10734,9 @@
       "dev": true
     },
     "node_modules/vite/node_modules/postcss": {
-      "version": "8.4.32",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.32.tgz",
-      "integrity": "sha512-D/kj5JNu6oo2EIy+XL/26JEDTlIbB8hw85G8StOE6L74RQAVVP5rej6wxCNqyMbR4RkPfqvezVbPw81Ngd6Kcw==",
+      "version": "8.4.38",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.38.tgz",
+      "integrity": "sha512-Wglpdk03BSfXkHoQa3b/oulrotAkwrlLDRSOb9D0bN86FdRyE9lppSp33aHNPgBa0JKCoB+drFLZkQoRRYae5A==",
       "funding": [
         {
           "type": "opencollective",
@@ -10710,7 +10754,7 @@
       "dependencies": {
         "nanoid": "^3.3.7",
         "picocolors": "^1.0.0",
-        "source-map-js": "^1.0.2"
+        "source-map-js": "^1.2.0"
       },
       "engines": {
         "node": "^10 || ^12 || >=14"

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "axios": "^1.6.7",
     "babel-plugin-styled-components": "^2.1.4",
     "chart.js": "^4.4.1",
-    "deck.gl": "8.6.6",
+    "deck.gl": "^9.0.6",
     "jsdom": "^24.0.0",
     "md5": "^2.3.0",
     "next": "14.1.0",


### PR DESCRIPTION
After this change, `npm audit` reports zero vulnerabilities. It seems to work for me, but could someone else please also verify that no bugs are introduced with this change?