### PR TITLE
Remove default arrow from toggle section

### DIFF
--- a/components/ToggleSection.tsx
+++ b/components/ToggleSection.tsx
@@ -25,27 +25,21 @@ const Arrow = styled(ArrowSvg)<{ open: boolean }>`
 const HeaderSection = styled.summary`
   display: flex;
   justify-content: space-between;
+  width: 100%;
+  list-style: none; /* remove default arrow in Firefox */
 
-  & .arrow {
-    display: block;
-  }
+  &::-webkit-details-marker {
+    display: none; /* remove default arrow in Chrome */
 
   &:hover {
     cursor: pointer;
+  }
   }
 `
 
 const InfoSection = styled.div`
   display: flex;
   flex-direction: column;
-
-  .mobile {
-    background: black;
-  }
-
-  .desktop {
-    background: yellow;
-  }
 `
 
 type Props = {
@@ -60,7 +54,7 @@ function ToggleSection({ header, text }: Props) {
     <TextSection onToggle={(event) => setOpen((event.target as HTMLDetailsElement).open)}>
       <HeaderSection>
         <H5>{header}</H5>
-        <Arrow open={open} className="arrow" />
+        <Arrow open={open} />
       </HeaderSection>
       <InfoSection>
         {typeof text === 'string' ? <Markdown>{text}</Markdown> : text}


### PR DESCRIPTION
Remove default arrow from toggle section plus minor cleanup.
Please test on actual mobile device!

Used to look like this:

![IMG_2960](https://github.com/Klimatbyran/klimatkollen/assets/7899748/173c2213-146f-4a51-a689-27f79a861d66)

Now like this on my iPhone:

![IMG_2962](https://github.com/Klimatbyran/klimatkollen/assets/7899748/2e7dc226-280e-4ac0-8ec1-bf98b04042b0)
