### PR TITLE
lower thresholds for consumption related emissions

### DIFF
--- a/public/locales/sv/common.json
+++ b/public/locales/sv/common.json
@@ -53,12 +53,12 @@
       "source": "Källa: [Stockholm Environment Institute](https://www.sei.org/tools/konsumtionskompassen/)",
       "title": "Konsumtionsutsläpp",
       "labels": [
-        "7 ton +",
-        "6,7-7 ton",
-        "6,4-6,7 ton",
-        "6,1-6,4 ton",
-        "5,8-6,1 ton",
-        "5,8 ton -"
+        "6,4 ton +",
+        "6,2-6,4 ton",
+        "6-6,2 ton",
+        "5,8-6 ton",
+        "5,6-5,8 ton",
+        "5,6 ton -"
       ],
       "name": "Konsumtionen"
     },

--- a/utils/datasetDefinitions.tsx
+++ b/utils/datasetDefinitions.tsx
@@ -95,7 +95,7 @@ function getTranslatedDataDescriptions(locale: string, _t: TFunction): DataDescr
       title: t('common:datasets.consumption.title'),
       body: t('common:datasets.consumption.body'),
       source: t('common:datasets.consumption.source'),
-      boundaries: [7, 6.7, 6.4, 6.1, 5.8],
+      boundaries: [6.4, 6.2, 6, 5.8, 5.6],
       labels:
       t('common:datasets.consumption.labels', { returnObjects: true }) as unknown as string[],
       labelRotateUp: [],


### PR DESCRIPTION
Change consumption related emissions boundaries from [7, 6.7, 6.4, 6.1, 5.8] to [6.4, 6.2, 6, 5.8, 5.6] in order to make map reflect acceptable levels.

Fix #365 