### PR TITLE
add hidden label to newsletter form

### DIFF
--- a/components/Footer/FooterNewsletterForm.tsx
+++ b/components/Footer/FooterNewsletterForm.tsx
@@ -53,6 +53,17 @@ const StyledForm = styled.form`
   flex-grow: 1;
 `
 
+const VisuallyHiddenLabel = styled.label`
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  margin: -1px;
+  padding: 0;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  border: 0;
+`
+
 const StyledInput = styled.input`
   background: ${({ theme }) => theme.darkGreenOne};
   border: none;
@@ -144,6 +155,7 @@ const NewsletterForm: FC<Props> = ({ status, onValidated }) => {
               <EmailValidation>{t('footer.signup-form.thanks')}</EmailValidation>
             ) : (
               <>
+                <VisuallyHiddenLabel htmlFor="signup">{t('footer.signup-form.label')}</VisuallyHiddenLabel>
                 <StyledInput
                   onChange={(event) => setEmail(event.target.value)}
                   type="email"

--- a/public/locales/sv/common.json
+++ b/public/locales/sv/common.json
@@ -106,6 +106,7 @@
     "open-source": "öppen källkod",
     "partners": "Partners",
     "signup-form": {
+      "label": "Prenumerera på vårt nyhetsbrev",
       "info": "Med vårt nyhetsbrev får du uppdateringar om hur det går med utsläppen och omställningen direkt i din mejl.",
       "placeholder": "Ange mailadress",
       "thanks": "Tack för ditt intresse!",


### PR DESCRIPTION
Add a hidden label to the newsletter signup form to ensure it complies with WAI-ARIA standards. It passed my WAI-ARIA Firefox extension check, but there could potentially be a more elegant solution, as this is not my strong suit.