### PR TITLE
Feature/newsletter anchor link and styling

### DIFF
--- a/components/Footer/FooterNewsletterForm.tsx
+++ b/components/Footer/FooterNewsletterForm.tsx
@@ -141,7 +141,7 @@ const NewsletterForm: FC<Props> = ({ status, onValidated }) => {
   }
 
   return (
-    <Container>
+    <Container id="newsletter">
       <H5>{t('footer.signup-form.title')}</H5>
       <HorizontalContainer>
         <div>

--- a/components/Footer/FooterNewsletterForm.tsx
+++ b/components/Footer/FooterNewsletterForm.tsx
@@ -45,6 +45,7 @@ const StyledParagraph = styled(Paragraph)`
 
 const StyledForm = styled.form`
   display: flex;
+  gap: 0.5rem;
   padding-bottom: 0.5rem;
   border-bottom: 1px solid ${({ theme }) => theme.midGreen};
   justify-content: space-between;
@@ -71,6 +72,7 @@ const StyledInput = styled.input`
   font-size: 16px;
   font-family: 'Borna';
   width: 100%;
+  padding: 0.5rem;
 
   ::placeholder,
   ::-webkit-input-placeholder {
@@ -90,6 +92,7 @@ const ArrowButton = styled.button`
   border: none;
   right: 0;
   cursor: pointer;
+  padding: 0.25rem;
 `
 
 const EmailValidation = styled.div`
@@ -142,24 +145,24 @@ const NewsletterForm: FC<Props> = ({ status, onValidated }) => {
 
   return (
     <Container id="newsletter">
-      <H5>{t('footer.signup-form.title')}</H5>
+      <H5>{t('common:footer.signup-form.title')}</H5>
       <HorizontalContainer>
         <div>
           <StyledParagraph>
-            {t('footer.signup-form.info')}
+            {t('common:footer.signup-form.info')}
           </StyledParagraph>
         </div>
         <div>
           <StyledForm onSubmit={handleFormSubmit}>
             {showThanks ? (
-              <EmailValidation>{t('footer.signup-form.thanks')}</EmailValidation>
+              <EmailValidation>{t('common:footer.signup-form.thanks')}</EmailValidation>
             ) : (
               <>
-                <VisuallyHiddenLabel htmlFor="signup">{t('footer.signup-form.label')}</VisuallyHiddenLabel>
+                <VisuallyHiddenLabel htmlFor="signup">{t('common:footer.signup-form.label')}</VisuallyHiddenLabel>
                 <StyledInput
                   onChange={(event) => setEmail(event.target.value)}
                   type="email"
-                  placeholder={t('footer.signup-form.placeholder')}
+                  placeholder={t('common:footer.signup-form.placeholder')}
                   value={email}
                   required
                   disabled={showThanks}

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -83,6 +83,8 @@ body {
 
 html {
   scroll-behavior: smooth;
+  /* The scroll padding should match the height of the fixed width header plus some offset to make it nicely aligned */
+  scroll-padding-top: 64px;
 }
 
 a {


### PR DESCRIPTION
## Included changes:

- Add anchor link to show the newsletter form directly
- Add scroll-padding-top to the root html element to allow scrolling to anchor links and still accounting for the fixed header.
- Improve newsletter form spacing and use consistent translation keys with namespace included

All pages that include the newsletter form will now support the anchor link `#newsletter` at the end of the URL. Thanks to the added scroll padding, this now gives a quite nice experience.


https://github.com/Klimatbyran/klimatkollen/assets/6125097/e1374005-e909-4957-8b59-ddf1be2ed535