### PR TITLE
refactor: make radio button menu into accessible button menu

### DIFF
--- a/components/DatasetButtonMenu.tsx
+++ b/components/DatasetButtonMenu.tsx
@@ -1,9 +1,8 @@
-import { Fragment } from 'react'
 import styled from 'styled-components'
 import { DataDescriptions, DatasetKey } from '../utils/types'
 import { devices } from '../utils/devices'
 
-const RadioContainer = styled.div`
+const ButtonContainer = styled.div`
   margin: 8px 0 32px 0;
   gap: 8px;
   display: flex;
@@ -17,33 +16,33 @@ const RadioContainer = styled.div`
   }
 `
 
-const RadioLabel = styled.label`
+const Button = styled.button<{active: boolean}>`
   padding: 8px 16px;
   font-family: 'Anonymous Pro';
   font-size: 16px;
   text-decoration: none;
+  line-height: 19px;
   color: ${({ theme }) => theme.offWhite};
   background: ${({ theme }) => theme.lightBlack};
   border: none;
   border-radius: 8px;
   white-space: nowrap;
+  box-sizing: border-box;
   cursor: pointer;
 
   &:hover {
     background: ${({ theme }) => theme.darkGreenTwo};
   }
-`
 
-const RadioInput = styled.input`
-  display: none;
-  &:checked + ${RadioLabel} {
-    color: ${({ theme }) => theme.black};
-    background: ${({ theme }) => theme.midGreen};
+  ${({ theme, active }) => active && `
+    color: ${theme.black};
+    background: ${theme.midGreen};
 
     &:hover {
-      background: ${({ theme }) => theme.lightGreen};
-    }
+      background-color: ${theme.lightGreen};
   }
+  `}
+
 `
 
 type MenuProps = {
@@ -52,24 +51,21 @@ type MenuProps = {
   dataDescriptions: DataDescriptions
 }
 
-function RadioButtonMenu({ selectedData, handleDataChange, dataDescriptions }: MenuProps) {
+function DatasetButtonMenu({ selectedData, handleDataChange, dataDescriptions }: MenuProps) {
   const datasetKeys = Object.keys(dataDescriptions) as DatasetKey[]
   return (
-    <RadioContainer>
+    <ButtonContainer>
       {datasetKeys.map((key) => (
-        <Fragment key={key}>
-          <RadioInput
-            type="radio"
-            id={key}
-            value={key}
-            checked={selectedData === key}
-            onChange={() => handleDataChange(key)}
-          />
-          <RadioLabel htmlFor={key}>{dataDescriptions[key].name}</RadioLabel>
-        </Fragment>
+        <Button
+          key={key}
+          active={selectedData === key}
+          onClick={() => handleDataChange(key)}
+        >
+          {dataDescriptions[key].name}
+        </Button>
       ))}
-    </RadioContainer>
+    </ButtonContainer>
   )
 }
 
-export default RadioButtonMenu
+export default DatasetButtonMenu

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -27,7 +27,7 @@ import {
   defaultDataView,
   secondaryDataView,
 } from '../utils/datasetDefinitions'
-import RadioButtonMenu from '../components/RadioButtonMenu'
+import DatasetButtonMenu from '../components/DatasetButtonMenu'
 import { listColumns, rankData } from '../utils/createMunicipalityList'
 import {
   isValidDataView,
@@ -176,7 +176,7 @@ function StartPage({ municipalities }: PropsType) {
       <PageWrapper backgroundColor="black">
         <Container>
           <H2Regular>{t('startPage:questionTitle')}</H2Regular>
-          <RadioButtonMenu
+          <DatasetButtonMenu
             selectedData={selectedDataset}
             handleDataChange={handleDataChange}
             dataDescriptions={dataDescriptions}


### PR DESCRIPTION
fix #518 

Right now a user can't navigate with keyboard to choose the different datasets due to the radio button input having display none and therefore is not accessible for assistive technologies. 

This solution uses native buttons instead of the custom styling of radio buttons, which have built in support for accessible navigation. 

There is now a lot of guidelines online on how to code more accessible and to meet requirements of the new [EU Accessibility Act](https://www.w3.org/TR/epub-a11y-eaa-mapping/) coming into place summer 2025.

Official accessibility guidelines: https://www.w3.org/WAI/standards-guidelines/wcag/ 