### PR TITLE
Fix/533 remove extra arrows for iOS details element

### DIFF
--- a/__tests__/index.test.tsx
+++ b/__tests__/index.test.tsx
@@ -91,7 +91,7 @@ describe('Home Page', () => {
 
   it('handles dataset change', () => {
     const newDataset = 'common:datasets.plans.name'
-    const radioButton = screen.getByLabelText(newDataset)
+    const radioButton = screen.getByText(newDataset)
     fireEvent.click(radioButton)
     expect(screen.getByText(newDataset)).toBeInTheDocument()
   })

--- a/components/FactSection.tsx
+++ b/components/FactSection.tsx
@@ -12,6 +12,10 @@ const Row = styled.summary`
   justify-content: space-between;
   margin: 0.8rem 0;
   cursor: pointer;
+  list-style: none; /* remove default arrow in Firefox */
+  &::-webkit-details-marker {
+    display: none; /* remove default arrow in Chrome */
+  }
 `
 
 const SectionLeft = styled.section`
@@ -19,10 +23,6 @@ const SectionLeft = styled.section`
   flex-direction: column;
   gap: 0.5rem;
   width: 90%;
-  list-style: none; /* remove default arrow in Firefox */
-  &::-webkit-details-marker {
-    display: none; /* remove default arrow in Chrome */
-  }
 `
 
 const SectionRight = styled.section`

--- a/components/FactSection.tsx
+++ b/components/FactSection.tsx
@@ -19,6 +19,10 @@ const SectionLeft = styled.section`
   flex-direction: column;
   gap: 0.5rem;
   width: 90%;
+  list-style: none; /* remove default arrow in Firefox */
+  &::-webkit-details-marker {
+    display: none; /* remove default arrow in Chrome */
+  }
 `
 
 const SectionRight = styled.section`

--- a/components/Municipality/ScorecardSection.tsx
+++ b/components/Municipality/ScorecardSection.tsx
@@ -19,6 +19,10 @@ const Row = styled.summary`
   align-items: center;
   gap: 4px;
   cursor: pointer;
+  list-style: none; /* remove default arrow in Firefox */
+  &::-webkit-details-marker {
+    display: none; /* remove default arrow in Chrome */
+  }
 `
 
 const InfoParagraph = styled(Paragraph)`

--- a/components/ToggleSection.tsx
+++ b/components/ToggleSection.tsx
@@ -11,7 +11,7 @@ const TextSection = styled.details`
   flex-direction: column;
 
   gap: 15px;
-  margin-bottom: 40px;
+  margin-bottom: 2rem;
 `
 
 const Arrow = styled(ArrowSvg)<{ open: boolean }>`
@@ -27,13 +27,14 @@ const HeaderSection = styled.summary`
   justify-content: space-between;
   width: 100%;
   list-style: none; /* remove default arrow in Firefox */
+  padding: 0.5rem 0;
 
   &::-webkit-details-marker {
     display: none; /* remove default arrow in Chrome */
+  }
 
   &:hover {
     cursor: pointer;
-  }
   }
 `
 


### PR DESCRIPTION
Fix #533 and make `ToggleSection` easier to press by increasing the clickable area.

Also fixed a broken test.