### PR TITLE
Feature: Add expand icon to comparison table to improve UX

### DIFF
--- a/components/ComparisonTable.tsx
+++ b/components/ComparisonTable.tsx
@@ -20,8 +20,14 @@ const StyledTable = styled.table`
   overflow-y: auto;
   border-collapse: collapse;
 
-  @media only screen and (${devices.mobile}) {
+  font-size: 0.7em;
+
+  @media only screen and (${devices.smallMobile}) {
     font-size: 0.8em;
+  }
+
+  @media only screen and (${devices.tablet}) {
+    font-size: 1em;
   }
 
   .data-header {
@@ -37,6 +43,7 @@ const StyledTable = styled.table`
     background: ${({ theme }) => theme.lightBlack};
     position: sticky;
     top: 0;
+    z-index: 30;
   }
 `
 
@@ -153,9 +160,9 @@ function ComparisonTable<T extends object>({
       {/* HACK: prevent table headers from changing size when toggling table rows. Not sure what causes the problem, but this fixes it. */}
       {dataType === 'companies' ? (
         <colgroup>
-          <col width="33%" />
-          <col width="33%" />
-          <col width="33%" />
+          <col width="35%" />
+          <col width="28%" />
+          <col width="37%" />
         </colgroup>
       ) : null}
 

--- a/components/FactSection.tsx
+++ b/components/FactSection.tsx
@@ -2,8 +2,8 @@ import styled from 'styled-components'
 import { useState } from 'react'
 
 import { H3, ParagraphBold } from './Typography'
-import Icon from '../public/icons/add_light_white.svg'
-import IconGreen from '../public/icons/remove_light_white.svg'
+import IconAdd from '../public/icons/add_light_white.svg'
+import IconRemove from '../public/icons/remove_light_white.svg'
 import Markdown from './Markdown'
 
 const Row = styled.summary`
@@ -74,7 +74,7 @@ function FactSection({ heading, data, info }: Props) {
         {info && (
         <SectionRight>
           <StyledIcon>
-            {open ? <IconGreen /> : <Icon />}
+            {open ? <IconRemove /> : <IconAdd />}
           </StyledIcon>
         </SectionRight>
         )}

--- a/components/Municipality/ScorecardSection.tsx
+++ b/components/Municipality/ScorecardSection.tsx
@@ -2,8 +2,8 @@ import styled from 'styled-components'
 import { useState } from 'react'
 
 import Markdown from '../Markdown'
-import Icon from '../../public/icons/add_light_green.svg'
-import IconGreen from '../../public/icons/remove_light_green.svg'
+import IconAdd from '../../public/icons/add_light_green.svg'
+import IconRemove from '../../public/icons/remove_light_green.svg'
 import { Paragraph } from '../Typography'
 import { devices } from '../../utils/devices'
 
@@ -70,7 +70,7 @@ function ScorecardSection({ heading, data, info }: Props) {
         {info && (
         <SectionRight>
           <StyledIcon>
-            {toggle ? <IconGreen /> : <Icon />}
+            {toggle ? <IconRemove /> : <IconAdd />}
           </StyledIcon>
         </SectionRight>
         )}

--- a/utils/createCompanyList.tsx
+++ b/utils/createCompanyList.tsx
@@ -3,11 +3,30 @@ import { ColumnDef, Row } from '@tanstack/react-table'
 import { TFunction } from 'i18next'
 
 import { Company } from './types'
+import ArrowSvg from '../public/icons/arrow-down-round.svg'
+import { colorTheme } from '../Theme'
+
+const Arrow = styled(ArrowSvg)<{ open: boolean }>`
+  transform: rotate(${(props) => (props.open ? '180deg' : '0')});
+
+  & path {
+    fill: ${(props) => (props.open ? colorTheme.lightGreen : colorTheme.offWhite)};
+  }
+`
 
 // IDEA: do something similar for the regional view to distinguish between actual important data (orange), and when something is missing (gray)
-const ScopeColumn = styled.span<{ isMissing: boolean }>`
+const ScopeColumn = styled.div<{ isMissing: boolean }>`
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
   color: ${({ isMissing, theme }) => (isMissing ? 'gray' : theme.darkYellow)};
   font-style: ${({ isMissing }) => (isMissing ? 'italic' : 'normal')};
+
+  .expandable {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+  }
 `
 
 const formatter = new Intl.NumberFormat('sv-SE', { maximumFractionDigits: 0 })
@@ -79,8 +98,9 @@ export const companyColumns = (t: TFunction): ColumnDef<Company>[] => {
         // it is in fact just a number or null.
         const scope3String = Number.isFinite(scope3Emissions) ? formatter.format(scope3Emissions as unknown as number) : notReported
         return (
-          <ScopeColumn isMissing={scope3String === notReported}>
+          <ScopeColumn isMissing={scope3String === notReported} className="expandable">
             {scope3String}
+            <Arrow open={row.cell.row.getIsExpanded()} />
           </ScopeColumn>
         )
       },

--- a/utils/createCompanyList.tsx
+++ b/utils/createCompanyList.tsx
@@ -3,26 +3,23 @@ import { ColumnDef, Row } from '@tanstack/react-table'
 import { TFunction } from 'i18next'
 
 import { Company } from './types'
-
-import IconAdd from '../public/icons/add_light_white.svg'
-import IconRemove from '../public/icons/remove_light_white.svg'
 import { devices } from './devices'
+import ArrowSvg from '../public/icons/arrow-down-round.svg'
+import { colorTheme } from '../Theme'
 
-// import ArrowSvg from '../public/icons/arrow-down-round.svg'
-// import { colorTheme } from '../Theme'
+const Arrow = styled(ArrowSvg)<{ open: boolean }>`
+  --scale: 0.6;
+  transform: scale(var(--scale)) rotate(${(props) => (props.open ? '180deg' : '0')});
 
-// const Arrow = styled(ArrowSvg)<{ open: boolean }>`
-//   --scale: 0.6;
-//   transform: scale(var(--scale)) rotate(${(props) => (props.open ? '180deg' : '0')});
+  & path {
+    fill: ${(props) => (props.open ? colorTheme.lightGreen : colorTheme.offWhite)};
+  }
 
-//   & path {
-//     fill: ${(props) => (props.open ? colorTheme.lightGreen : colorTheme.offWhite)};
-//   }
+  @media only screen and (${devices.tablet}) {
+    --scale: 0.8;
+  }
+`
 
-//   @media only screen and (${devices.tablet}) {
-//     --scale: 0.8;
-//   }
-// `
 // IDEA: do something similar for the regional view to distinguish between actual important data (orange), and when something is missing (gray)
 const ScopeColumn = styled.span<{ isMissing: boolean }>`
   display: inline-flex;
@@ -109,8 +106,7 @@ export const companyColumns = (t: TFunction): ColumnDef<Company>[] => {
         return (
           <ScopeColumn isMissing={scope3String === notReported}>
             {scope3String}
-            {/* <Arrow open={row.cell.row.getIsExpanded()} /> */}
-            {row.cell.row.getIsExpanded() ? <IconRemove /> : <IconAdd />}
+            <Arrow open={row.cell.row.getIsExpanded()} />
           </ScopeColumn>
         )
       },

--- a/utils/createCompanyList.tsx
+++ b/utils/createCompanyList.tsx
@@ -3,30 +3,39 @@ import { ColumnDef, Row } from '@tanstack/react-table'
 import { TFunction } from 'i18next'
 
 import { Company } from './types'
-import ArrowSvg from '../public/icons/arrow-down-round.svg'
-import { colorTheme } from '../Theme'
 
-const Arrow = styled(ArrowSvg)<{ open: boolean }>`
-  transform: rotate(${(props) => (props.open ? '180deg' : '0')});
+import IconAdd from '../public/icons/add_light_white.svg'
+import IconRemove from '../public/icons/remove_light_white.svg'
+import { devices } from './devices'
 
-  & path {
-    fill: ${(props) => (props.open ? colorTheme.lightGreen : colorTheme.offWhite)};
-  }
-`
+// import ArrowSvg from '../public/icons/arrow-down-round.svg'
+// import { colorTheme } from '../Theme'
 
+// const Arrow = styled(ArrowSvg)<{ open: boolean }>`
+//   --scale: 0.6;
+//   transform: scale(var(--scale)) rotate(${(props) => (props.open ? '180deg' : '0')});
+
+//   & path {
+//     fill: ${(props) => (props.open ? colorTheme.lightGreen : colorTheme.offWhite)};
+//   }
+
+//   @media only screen and (${devices.tablet}) {
+//     --scale: 0.8;
+//   }
+// `
 // IDEA: do something similar for the regional view to distinguish between actual important data (orange), and when something is missing (gray)
-const ScopeColumn = styled.div<{ isMissing: boolean }>`
+const ScopeColumn = styled.span<{ isMissing: boolean }>`
   display: inline-flex;
   align-items: center;
-  gap: 0.5rem;
-  color: ${({ isMissing, theme }) => (isMissing ? 'gray' : theme.darkYellow)};
-  font-style: ${({ isMissing }) => (isMissing ? 'italic' : 'normal')};
+  gap: 0.25rem;
 
-  .expandable {
-    display: flex;
-    align-items: center;
+  @media only screen and (${devices.smallMobile}) {
     gap: 0.5rem;
   }
+
+  color: ${({ isMissing, theme }) => (isMissing ? 'gray' : theme.darkYellow)};
+  font-style: ${({ isMissing }) => (isMissing ? 'italic' : 'normal')};
+  font-size: ${({ isMissing }) => (isMissing ? '0.9em' : '')};
 `
 
 const formatter = new Intl.NumberFormat('sv-SE', { maximumFractionDigits: 0 })
@@ -98,9 +107,10 @@ export const companyColumns = (t: TFunction): ColumnDef<Company>[] => {
         // it is in fact just a number or null.
         const scope3String = Number.isFinite(scope3Emissions) ? formatter.format(scope3Emissions as unknown as number) : notReported
         return (
-          <ScopeColumn isMissing={scope3String === notReported} className="expandable">
+          <ScopeColumn isMissing={scope3String === notReported}>
             {scope3String}
-            <Arrow open={row.cell.row.getIsExpanded()} />
+            {/* <Arrow open={row.cell.row.getIsExpanded()} /> */}
+            {row.cell.row.getIsExpanded() ? <IconRemove /> : <IconAdd />}
           </ScopeColumn>
         )
       },


### PR DESCRIPTION
This makes it more obvious there is more info available for each row.

I experimented with two alternatives, and based on feedback from people I asked, alternative 2 seems to be the best. Alternative 2 is now implemented.

### Alternative 1:
![image](https://github.com/Klimatbyran/klimatkollen/assets/6125097/6cfd43cf-12eb-40ee-aeab-119d0f195e47)

### Alternative 2:
![image](https://github.com/Klimatbyran/klimatkollen/assets/6125097/9e918833-cdc2-4cb8-a720-23f619d918d1)
