### PR TITLE
Feature: Add sorting icons for table columns to make it easier to know you can sort change the sorting

### DIFF
--- a/components/ComparisonTable.tsx
+++ b/components/ComparisonTable.tsx
@@ -129,8 +129,6 @@ function ComparisonTable<T extends object>({
 
   const [resizeCount, setResizeCount] = useState(0)
 
-  console.log(sorting[0])
-
   useEffect(() => {
     const handleResize = () => setResizeCount((count) => count + 1)
     window.addEventListener('resize', handleResize)
@@ -172,15 +170,6 @@ function ComparisonTable<T extends object>({
     }
   }
 
-  // console.log(columns[0], table.getHeaderGroups()[0].headers[0])
-
-  // useEffect(() => {
-  //   // Add default sorting to the first column
-  //   if (!sorting.length) {
-  //     setSorting([{ id: table.getHeaderGroups()[0]?.headers?.[0]?.id, desc: false }])
-  //   }
-  // }, [table, sorting.length])
-
   return (
     <StyledTable key={resizeCount}>
       {/* HACK: prevent table headers from changing size when toggling table rows. Not sure what causes the problem, but this fixes it. */}
@@ -215,10 +204,6 @@ function ComparisonTable<T extends object>({
                       // display: header.column.getIsSorted() === false ? 'none' : '',
                     }}
                   />
-                  {/* {{
-                    asc: <IconArrow style={{ transform: 'rotate(90deg) scale(0.6)' }} />,
-                    desc: <IconArrow style={{ transform: 'rotate(-90deg) scale(0.6)' }} />,
-                  }[header.column.getIsSorted() as string] ?? null} */}
                 </TableHeaderInner>
               </TableHeader>
             ))}

--- a/utils/createCompanyList.tsx
+++ b/utils/createCompanyList.tsx
@@ -65,7 +65,7 @@ export const companyColumns = (t: TFunction): ColumnDef<Company>[] => {
           </ScopeColumn>
         )
       },
-      sortingFn: getCustomSortFn({ scope: 'Scope1n2' }),
+      sortingFn: getCustomSortFn({ scope: 'Scope1n2', sortAscending: true }),
       accessorKey: 'Emissions.Scope1n2',
     },
     {
@@ -84,7 +84,7 @@ export const companyColumns = (t: TFunction): ColumnDef<Company>[] => {
           </ScopeColumn>
         )
       },
-      sortingFn: getCustomSortFn({ scope: 'Scope3' }),
+      sortingFn: getCustomSortFn({ scope: 'Scope3', sortAscending: true }),
       accessorKey: 'Emissions.Scope3',
     },
   ]


### PR DESCRIPTION
Fix #405 

This PR implements sorting icons for `ComparisonTable` which will now work for both `CompanyView` and `RegionalView`.

This PR also changes sorting to always be enabled by default (to always show an icon).

## Remaining tasks
- [ ] Figure out a way to ensure arrows are visible correctly on all screen sizes. See TODO comments in [3556a18fa3320064fba5415267ec11ef52b33ac3](https://github.com/Klimatbyran/klimatkollen/commit/3556a18fa3320064fba5415267ec11ef52b33ac3) for more info.