### PR TITLE
Refactor and bugfixes: Improve routing, state management and caching for dataViews

### DIFF
--- a/components/PillSwitch.tsx
+++ b/components/PillSwitch.tsx
@@ -5,7 +5,7 @@ import Link from 'next/link'
 
 import { devices } from '../utils/devices'
 
-const SwitchLabel = styled.div`
+const Switch = styled.div`
   position: relative;
   display: flex;
   align-items: center;
@@ -72,11 +72,14 @@ type PillSwitchProps = {
 
 function PillSwitch({ isActive }: PillSwitchProps) {
   return (
-    <SwitchLabel aria-label={t('common:components.PillSwitch.label')}>
-      <DataGroupLink href="/foretag/utslappen/lista">Företag</DataGroupLink>
-      <DataGroupLink href="/geografiskt/utslappen/lista">Kommuner</DataGroupLink>
-      <Slider isActive={isActive} />
-    </SwitchLabel>
+    <>
+      <p className="sr-only">{t('common:components.PillSwitch.label')}</p>
+      <Switch>
+        <DataGroupLink href="/foretag/utslappen/lista">Företag</DataGroupLink>
+        <DataGroupLink href="/geografiskt/utslappen/lista">Kommuner</DataGroupLink>
+        <Slider isActive={isActive} />
+      </Switch>
+    </>
   )
 }
 

--- a/components/PillSwitch.tsx
+++ b/components/PillSwitch.tsx
@@ -1,14 +1,16 @@
 import React from 'react'
 import styled from 'styled-components'
 import { t } from 'i18next'
+import Link from 'next/link'
+
 import { devices } from '../utils/devices'
 
-const SwitchLabel = styled.label`
+const SwitchLabel = styled.div`
   position: relative;
   display: flex;
   align-items: center;
   justify-content: space-between;
-  width: 240px; 
+  width: 240px;
   height: 40px;
   background: ${({ theme }) => theme.lightBlack};
   border-radius: 12px;
@@ -16,7 +18,7 @@ const SwitchLabel = styled.label`
   cursor: pointer;
 
   @media only screen and (${devices.tablet}) {
-    width: 264px; 
+    width: 264px;
     height: 56px;
     margin-bottom: 40px;
   }
@@ -37,66 +39,43 @@ const Slider = styled.div<{ isActive: boolean }>`
   font-size: 14px;
   font-weight: bold;
   z-index: 1;
+  pointer-events: none;
 
   @media only screen and (${devices.tablet}) {
     height: 48px; /* height of the slider */
   }
 `
 
-const SwitchInput = styled.input`
-  opacity: 0;
-  width: 0;
-  height: 0;
-`
-
-const TextLeft = styled.span`
+const DataGroupLink = styled(Link)`
   position: absolute;
   width: 50%;
-  left: 0px;
-  text-align: center;
+  height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
   color: ${({ theme }) => theme.offWhite};
-  pointer-events: none; /* ignore pointer events so label still triggers input */
-  z-index: 10;
-`
+  z-index: 20;
+  text-decoration: none;
 
-const TextRight = styled.span`
-  position: absolute;
-  width: 50%;
-  right: 0px;
-  text-align: center;
-  color: ${({ theme }) => theme.offWhite};
-  pointer-events: none;
-  z-index: 10;
+  &:first-of-type {
+    left: 0px;
+  }
+
+  &:last-of-type {
+    right: 0px;
+  }
 `
 
 type PillSwitchProps = {
-  onToggle: (isActive: boolean) => void
   isActive: boolean
 }
 
-function PillSwitch({ onToggle, isActive }: PillSwitchProps) {
-  const handleToggle = () => {
-    const newIsActive = !isActive
-    onToggle(newIsActive)
-  }
-
-  const handleKeyDown = (event: React.KeyboardEvent) => {
-    if (event.key === 'Enter') {
-      handleToggle()
-    }
-  }
-
+function PillSwitch({ isActive }: PillSwitchProps) {
   return (
-    <SwitchLabel onKeyDown={handleKeyDown} tabIndex={0} aria-label={t('common:components.PillSwitch.label')}>
-      <TextLeft>Företag</TextLeft>
-      <TextRight>Kommuner</TextRight>
+    <SwitchLabel aria-label={t('common:components.PillSwitch.label')}>
+      <DataGroupLink href="/foretag/utslappen/lista">Företag</DataGroupLink>
+      <DataGroupLink href="/geografiskt/utslappen/lista">Kommuner</DataGroupLink>
       <Slider isActive={isActive} />
-      <SwitchInput
-        type="checkbox"
-        role="switch"
-        checked={isActive}
-        onChange={handleToggle}
-      />
     </SwitchLabel>
   )
 }

--- a/components/PillSwitch.tsx
+++ b/components/PillSwitch.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import React from 'react'
 import styled from 'styled-components'
 import { t } from 'i18next'
 import { devices } from '../utils/devices'
@@ -71,14 +71,12 @@ const TextRight = styled.span`
 
 type PillSwitchProps = {
   onToggle: (isActive: boolean) => void
+  isActive: boolean
 }
 
-function PillSwitch({ onToggle }: PillSwitchProps) {
-  const [isActive, setIsActive] = useState(false)
-
+function PillSwitch({ onToggle, isActive }: PillSwitchProps) {
   const handleToggle = () => {
     const newIsActive = !isActive
-    setIsActive(newIsActive)
     onToggle(newIsActive)
   }
 
@@ -96,10 +94,8 @@ function PillSwitch({ onToggle }: PillSwitchProps) {
       <SwitchInput
         type="checkbox"
         role="switch"
-        aria-checked={isActive}
         checked={isActive}
-        onClick={handleToggle}
-        readOnly
+        onChange={handleToggle}
       />
     </SwitchLabel>
   )

--- a/components/PillSwitch.tsx
+++ b/components/PillSwitch.tsx
@@ -68,14 +68,16 @@ const DataGroupLink = styled(Link)`
 
 type PillSwitchProps = {
   isActive: boolean
+  links: {text: string, href: string}[]
 }
 
-function PillSwitch({ isActive }: PillSwitchProps) {
+function PillSwitch({ isActive, links }: PillSwitchProps) {
   const { t } = useTranslation()
   return (
     <Switch aria-label={t('common:components.PillSwitch.label')}>
-      <DataGroupLink href="/foretag/utslappen/lista">Företag</DataGroupLink>
-      <DataGroupLink href="/geografiskt/utslappen/lista">Kommuner</DataGroupLink>
+      {links.map(({ text, href }) => (
+        <DataGroupLink href={href}>{text}</DataGroupLink>
+      ))}
       <Slider isActive={isActive} />
     </Switch>
   )

--- a/components/PillSwitch.tsx
+++ b/components/PillSwitch.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import styled from 'styled-components'
-import { t } from 'i18next'
 import Link from 'next/link'
+import { useTranslation } from 'next-i18next'
 
 import { devices } from '../utils/devices'
 
@@ -71,15 +71,13 @@ type PillSwitchProps = {
 }
 
 function PillSwitch({ isActive }: PillSwitchProps) {
+  const { t } = useTranslation()
   return (
-    <>
-      <p className="sr-only">{t('common:components.PillSwitch.label')}</p>
-      <Switch>
-        <DataGroupLink href="/foretag/utslappen/lista">Företag</DataGroupLink>
-        <DataGroupLink href="/geografiskt/utslappen/lista">Kommuner</DataGroupLink>
-        <Slider isActive={isActive} />
-      </Switch>
-    </>
+    <Switch aria-label={t('common:components.PillSwitch.label')}>
+      <DataGroupLink href="/foretag/utslappen/lista">Företag</DataGroupLink>
+      <DataGroupLink href="/geografiskt/utslappen/lista">Kommuner</DataGroupLink>
+      <Slider isActive={isActive} />
+    </Switch>
   )
 }
 

--- a/pages/[dataGroup]/[dataset]/[dataView]/index.tsx
+++ b/pages/[dataGroup]/[dataset]/[dataView]/index.tsx
@@ -3,7 +3,6 @@ import { ParsedUrlQuery } from 'querystring'
 import { Company as TCompany, Municipality as TMunicipality } from '../../../../utils/types'
 import StartPage from '../../..'
 import { ClimateDataService } from '../../../../utils/climateDataService'
-import { normalizeString } from '../../../../utils/shared'
 import Layout from '../../../../components/Layout'
 import Footer from '../../../../components/Footer/Footer'
 import { CompanyDataService } from '../../../../utils/companyDataService'
@@ -24,19 +23,14 @@ const cache = new Map()
 export const getServerSideProps: GetServerSideProps = async ({
   params, res, locale,
 }) => {
-  const dataset = (params as Params).dataset as string
-  const dataView = (params as Params).dataView as string
+  const { dataset, dataView } = params as Params
   const { t, _nextI18Next } = await getServerSideI18n(locale as string, ['common', 'startPage'])
-  const { isValidDataset } = getDataDescriptions(locale as string, t)
+  const { getDataset, getDataView } = getDataDescriptions(locale as string, t)
 
-  const normalizedDataset = normalizeString(dataset)
-  const normalizedDataView = normalizeString(dataView)
+  const normalizedDataset = getDataset(dataset)
+  const normalizedDataView = getDataView(dataView)
 
-  if (!isValidDataset(normalizedDataset) || !isValidDataView(normalizedDataView)) {
-    return {
-      notFound: true, // Return a 404 page
-    }
-  } if (dataset !== normalizedDataset || dataView !== normalizedDataView) {
+  if (dataset !== normalizedDataset || dataView !== normalizedDataView) {
     return {
       redirect: {
         destination: `/${normalizedDataset}/${normalizedDataView}`,

--- a/pages/[dataGroup]/[dataset]/[dataView]/index.tsx
+++ b/pages/[dataGroup]/[dataset]/[dataView]/index.tsx
@@ -22,6 +22,24 @@ interface Params extends ParsedUrlQuery {
 
 const cache = new Map()
 
+function getCompanies() {
+  const cached = cache.get('companies')
+  if (cached) return cached
+
+  const companies = new CompanyDataService().getCompanies()
+  cache.set('companies', companies)
+  return companies
+}
+
+function getMunicipalities() {
+  const cached = cache.get('municipalities')
+  if (cached) return cached
+
+  const municipalities = new ClimateDataService().getMunicipalities()
+  cache.set('municipalities', municipalities)
+  return municipalities
+}
+
 export const getServerSideProps: GetServerSideProps = async ({
   params, res, locale,
 }) => {
@@ -42,15 +60,6 @@ export const getServerSideProps: GetServerSideProps = async ({
     }
   }
 
-  const cacheKey = `${normalizedDataGroup}/${normalizedDataset}`
-
-  if (cache.get(cacheKey)) {
-    return cache.get(cacheKey)
-  }
-
-  const municipalities = new ClimateDataService().getMunicipalities()
-  const companies = new CompanyDataService().getCompanies()
-
   res.setHeader(
     'Cache-Control',
     `public, stale-while-revalidate=60, max-age=${ONE_WEEK_MS}`,
@@ -58,14 +67,13 @@ export const getServerSideProps: GetServerSideProps = async ({
 
   const result = {
     props: {
-      companies,
-      municipalities,
+      companies: getCompanies(),
+      municipalities: getMunicipalities(),
       normalizedDataset,
       _nextI18Next,
     },
   }
 
-  cache.set(cacheKey, result)
   return result
 }
 

--- a/pages/[dataGroup]/[dataset]/[dataView]/index.tsx
+++ b/pages/[dataGroup]/[dataset]/[dataView]/index.tsx
@@ -3,7 +3,7 @@ import { ParsedUrlQuery } from 'querystring'
 import { Company as TCompany, Municipality as TMunicipality } from '../../../../utils/types'
 import StartPage from '../../..'
 import { ClimateDataService } from '../../../../utils/climateDataService'
-import { isValidDataView, normalizeString } from '../../../../utils/shared'
+import { normalizeString } from '../../../../utils/shared'
 import Layout from '../../../../components/Layout'
 import Footer from '../../../../components/Footer/Footer'
 import { CompanyDataService } from '../../../../utils/companyDataService'
@@ -12,6 +12,7 @@ import { getServerSideI18n } from '../../../../utils/getServerSideI18n'
 
 export const defaultDataView = 'lista'
 export const secondaryDataView = 'karta'
+export const isValidDataView = (dataView: string) => [defaultDataView, secondaryDataView].includes(dataView)
 
 interface Params extends ParsedUrlQuery {
   dataset: string

--- a/pages/[dataGroup]/[dataset]/[dataView]/index.tsx
+++ b/pages/[dataGroup]/[dataset]/[dataView]/index.tsx
@@ -8,6 +8,7 @@ import Footer from '../../../../components/Footer/Footer'
 import { CompanyDataService } from '../../../../utils/companyDataService'
 import { getDataDescriptions } from '../../../../utils/datasetDefinitions'
 import { getServerSideI18n } from '../../../../utils/getServerSideI18n'
+import { ONE_WEEK_MS } from '../../../../utils/shared'
 
 export const defaultDataView = 'lista'
 export const secondaryDataView = 'karta'
@@ -52,7 +53,7 @@ export const getServerSideProps: GetServerSideProps = async ({
 
   res.setHeader(
     'Cache-Control',
-    `public, stale-while-revalidate=60, max-age=${60 * 60 * 24 * 7}`,
+    `public, stale-while-revalidate=60, max-age=${ONE_WEEK_MS}`,
   )
 
   const result = {

--- a/pages/api/map.tsx
+++ b/pages/api/map.tsx
@@ -1,12 +1,14 @@
 import type { NextApiRequest, NextApiResponse } from 'next'
+
 import kommuner from '../data/kommuner.json'
+import { ONE_WEEK_MS } from '../../utils/shared'
 
 export default function userHandler(req: NextApiRequest, res: NextApiResponse) {
   const { method } = req
 
   switch (method) {
     case 'GET':
-      res.setHeader('Cache-Control', 'public, s-maxage=604800') // a week
+      res.setHeader('Cache-Control', `public, stale-while-revalidate=60, max-age=${ONE_WEEK_MS}`)
       res.json(kommuner)
       break
     default:

--- a/pages/api/municipalities.tsx
+++ b/pages/api/municipalities.tsx
@@ -1,5 +1,6 @@
 import type { NextApiRequest, NextApiResponse } from 'next'
 import { ClimateDataService } from '../../utils/climateDataService'
+import { ONE_WEEK_MS } from '../../utils/shared'
 
 export default function userHandler(req: NextApiRequest, res: NextApiResponse) {
   const {
@@ -13,7 +14,7 @@ export default function userHandler(req: NextApiRequest, res: NextApiResponse) {
         if (municipalities.length < 1) {
           res.status(404).json('Inga kommuner hittades')
         } else {
-          res.setHeader('Cache-Control', `public, stale-while-revalidate=60, max-age=${((60 * 60) * 24) * 7}`)
+          res.setHeader('Cache-Control', `public, stale-while-revalidate=60, max-age=${ONE_WEEK_MS}`)
           res.status(200).json(municipalities)
         }
       } catch (error) {

--- a/pages/in-english/index.tsx
+++ b/pages/in-english/index.tsx
@@ -11,6 +11,7 @@ import PageWrapper from '../../components/PageWrapper'
 import Layout from '../../components/Layout'
 import Footer from '../../components/Footer/Footer'
 import { Grid, GridImage, GridItem } from '../../components/shared'
+import { ONE_WEEK_MS } from '../../utils/shared'
 
 const Ola = '/team/ola.jpg'
 const Frida = '/team/frida.jpg'
@@ -380,7 +381,7 @@ function InEnglish() {
 export const getServerSideProps: GetServerSideProps = async ({ res, locale }) => {
   res.setHeader(
     'Cache-Control',
-    `public, stale-while-revalidate=60, max-age=${60 * 60 * 24 * 7}`,
+    `public, stale-while-revalidate=60, max-age=${ONE_WEEK_MS}`,
   )
 
   return {

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -18,7 +18,7 @@ import RegionalView from '../components/RegionalView'
 import CompanyView from '../components/CompanyView'
 import PillSwitch from '../components/PillSwitch'
 import { defaultDataView } from './[dataGroup]/[dataset]/[dataView]'
-import { normalizeString } from '../utils/shared'
+import { ONE_WEEK_MS, normalizeString } from '../utils/shared'
 
 const Container = styled.div`
   display: flex;
@@ -93,7 +93,7 @@ function StartPage({ companies, municipalities }: PropsType) {
 export const getServerSideProps: GetServerSideProps = async ({ res, locale }) => {
   res.setHeader(
     'Cache-Control',
-    `public, stale-while-revalidate=60, max-age=${60 * 60 * 24 * 7}`,
+    `public, stale-while-revalidate=60, max-age=${ONE_WEEK_MS}`,
   )
 
   return {

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -35,10 +35,13 @@ type PropsType = {
   municipalities: Array<Municipality>
 }
 
+const primaryDataGroup = 'foretag'
+const secondaryDataGroup = 'geografiskt'
+
 function StartPage({ companies, municipalities }: PropsType) {
   const router = useRouter()
   const routeDataset = router.query.dataset
-  const { dataView } = router.query
+  const { dataGroup, dataView } = router.query
   const { t } = useTranslation()
   const { dataDescriptions, isValidDataset } = getDataDescriptions(router.locale as string, t)
 
@@ -48,15 +51,15 @@ function StartPage({ companies, municipalities }: PropsType) {
   const [selectedDataset, setSelectedDataset] = useState<DatasetKey>(defaultDataset)
   const [selectedDataView, setSelectedDataView] = useState(normalizedDataView)
 
-  const [showCompanyData, setShowCompanyData] = useState(true)
+  const [showCompanyData, setShowCompanyData] = useState(dataGroup === primaryDataGroup)
 
   const handleToggle = () => {
     setShowCompanyData(!showCompanyData)
     setSelectedDataset(defaultDataset)
     setSelectedDataView(defaultDataView)
 
-    const dataGroup = showCompanyData ? 'geografiskt' : 'foretag'
-    const path = `/${dataGroup}/${defaultDataset}/${defaultDataView}`
+    const newDataGroup = dataGroup === primaryDataGroup ? secondaryDataGroup : primaryDataGroup
+    const path = `/${newDataGroup}/${defaultDataset}/${defaultDataView}`
 
     router.push(path, undefined, { shallow: true })
   }
@@ -81,12 +84,10 @@ function StartPage({ companies, municipalities }: PropsType) {
       />
       <PageWrapper backgroundColor="black" compact={showCompanyData}>
         <Container>
-          <PillSwitch onToggle={handleToggle} />
+          <PillSwitch onToggle={handleToggle} isActive={!showCompanyData} />
           {showCompanyData
             ? (
-              <CompanyView
-                companies={companies}
-              />
+              <CompanyView companies={companies} />
             )
             : (
               <RegionalView

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -18,6 +18,7 @@ import RegionalView from '../components/RegionalView'
 import CompanyView from '../components/CompanyView'
 import PillSwitch from '../components/PillSwitch'
 import { defaultDataView } from './[dataGroup]/[dataset]/[dataView]'
+import { normalizeString } from '../utils/shared'
 
 const Container = styled.div`
   display: flex;
@@ -31,8 +32,19 @@ type PropsType = {
   municipalities: Array<Municipality>
 }
 
-const primaryDataGroup = 'foretag'
-const secondaryDataGroup = 'geografiskt'
+export const defaultDataGroup = 'foretag'
+export const secondaryDataGroup = 'geografiskt'
+const dataGroups = new Set([defaultDataGroup, secondaryDataGroup])
+export type DataGroup = typeof defaultDataGroup | typeof secondaryDataGroup
+
+export function getDataGroup(rawDataGroup: string): DataGroup {
+  const normalized = normalizeString(rawDataGroup)
+  if (dataGroups.has(normalized)) {
+    return normalized as DataGroup
+  }
+
+  return defaultDataGroup
+}
 
 function StartPage({ companies, municipalities }: PropsType) {
   const router = useRouter()
@@ -42,21 +54,12 @@ function StartPage({ companies, municipalities }: PropsType) {
     dataDescriptions, getDataset, getDataView,
   } = getDataDescriptions(router.locale as string, t)
 
+  const normalizedDataGroup = getDataGroup(dataGroup as string)
+
   const [selectedDataset, setSelectedDataset] = useState<DatasetKey>(getDataset(routeDataset as string))
   const [selectedDataView, setSelectedDataView] = useState(getDataView(dataView as string))
 
-  const [showCompanyData, setShowCompanyData] = useState(dataGroup === primaryDataGroup)
-
-  const handleToggle = () => {
-    setShowCompanyData(!showCompanyData)
-    setSelectedDataset(defaultDataset)
-    setSelectedDataView(defaultDataView)
-
-    const newDataGroup = dataGroup === primaryDataGroup ? secondaryDataGroup : primaryDataGroup
-    const path = `/${newDataGroup}/${defaultDataset}/${defaultDataView}`
-
-    router.push(path, undefined, { shallow: true })
-  }
+  const showCompanyData = normalizedDataGroup === defaultDataGroup
 
   return (
     <>
@@ -66,7 +69,7 @@ function StartPage({ companies, municipalities }: PropsType) {
       />
       <PageWrapper backgroundColor="black" compact={showCompanyData}>
         <Container>
-          <PillSwitch onToggle={handleToggle} isActive={!showCompanyData} />
+          <PillSwitch isActive={!showCompanyData} />
           {showCompanyData
             ? (
               <CompanyView companies={companies} />

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -69,7 +69,13 @@ function StartPage({ companies, municipalities }: PropsType) {
       />
       <PageWrapper backgroundColor="black" compact={showCompanyData}>
         <Container>
-          <PillSwitch isActive={!showCompanyData} />
+          <PillSwitch
+            isActive={!showCompanyData}
+            links={[
+              { text: 'Företag', href: '/foretag/utslappen/lista' },
+              { text: 'Kommuner', href: `/geografiskt/${selectedDataset}/${selectedDataView}` },
+            ]}
+          />
           {showCompanyData
             ? (
               <CompanyView companies={companies} />

--- a/pages/kallor-och-metod/index.tsx
+++ b/pages/kallor-och-metod/index.tsx
@@ -11,6 +11,7 @@ import PageWrapper from '../../components/PageWrapper'
 import Layout from '../../components/Layout'
 import Footer from '../../components/Footer/Footer'
 import ToggleSection from '../../components/ToggleSection'
+import { ONE_WEEK_MS } from '../../utils/shared'
 
 const Container = styled.section`
   display: flex;
@@ -64,7 +65,7 @@ export const getServerSideProps: GetServerSideProps = async ({ res, locale }) =>
 
   res.setHeader(
     'Cache-Control',
-    `public, stale-while-revalidate=60, max-age=${60 * 60 * 24 * 7}`,
+    `public, stale-while-revalidate=60, max-age=${ONE_WEEK_MS}`,
   )
 
   return {

--- a/pages/kommun/[municipality]/[step].tsx
+++ b/pages/kommun/[municipality]/[step].tsx
@@ -8,6 +8,7 @@ import { ClimateDataService } from '../../../utils/climateDataService'
 import { WikiDataService } from '../../../utils/wikiDataService'
 import { Municipality as TMunicipality } from '../../../utils/types'
 import { PoliticalRuleService } from '../../../utils/politicalRuleService'
+import { ONE_WEEK_MS } from '../../../utils/shared'
 
 const Municipality = dynamic(() => import('../../../components/Municipality/Municipality'))
 
@@ -75,7 +76,7 @@ interface Params extends ParsedUrlQuery {
 const cache = new Map()
 
 export const getServerSideProps: GetServerSideProps = async ({ params, res, locale }) => {
-  res.setHeader('Cache-Control', `public, stale-while-revalidate=60, max-age=${((60 * 60) * 24) * 7}`)
+  res.setHeader('Cache-Control', `public, stale-while-revalidate=60, max-age=${ONE_WEEK_MS}`)
 
   const id = (params as Params).municipality as string
   if (cache.get(id)) {

--- a/pages/om-oss/index.tsx
+++ b/pages/om-oss/index.tsx
@@ -16,6 +16,7 @@ import {
 } from '../../components/shared'
 import ToggleSection from '../../components/ToggleSection'
 import Markdown from '../../components/Markdown'
+import { ONE_WEEK_MS } from '../../utils/shared'
 
 const Ola = '/team/ola.jpg'
 const Frida = '/team/frida.jpg'
@@ -210,7 +211,7 @@ function OmOss() {
 export const getServerSideProps: GetServerSideProps = async ({ res, locale }) => {
   res.setHeader(
     'Cache-Control',
-    `public, stale-while-revalidate=60, max-age=${60 * 60 * 24 * 7}`,
+    `public, stale-while-revalidate=60, max-age=${ONE_WEEK_MS}`,
   )
 
   return {

--- a/pages/partierna/index.tsx
+++ b/pages/partierna/index.tsx
@@ -12,6 +12,7 @@ import Layout from '../../components/Layout'
 import Footer from '../../components/Footer/Footer'
 import { devices } from '../../utils/devices'
 import Markdown from '../../components/Markdown'
+import { ONE_WEEK_MS } from '../../utils/shared'
 
 const Container = styled.section`
   display: flex;
@@ -65,7 +66,7 @@ function Partier() {
 export const getServerSideProps: GetServerSideProps = async ({ res, locale }) => {
   res.setHeader(
     'Cache-Control',
-    `public, stale-while-revalidate=60, max-age=${60 * 60 * 24 * 7}`,
+    `public, stale-while-revalidate=60, max-age=${ONE_WEEK_MS}`,
   )
 
   return {

--- a/pages/utslappsberakningar/index.tsx
+++ b/pages/utslappsberakningar/index.tsx
@@ -13,6 +13,7 @@ import Layout from '../../components/Layout'
 import Footer from '../../components/Footer/Footer'
 import { devices } from '../../utils/devices'
 import Markdown from '../../components/Markdown'
+import { ONE_WEEK_MS } from '../../utils/shared'
 
 const Container = styled.section`
   display: flex;
@@ -78,7 +79,7 @@ export const getServerSideProps: GetServerSideProps = async ({ res, locale }) =>
 
   res.setHeader(
     'Cache-Control',
-    `public, stale-while-revalidate=60, max-age=${60 * 60 * 24 * 7}`,
+    `public, stale-while-revalidate=60, max-age=${ONE_WEEK_MS}`,
   )
 
   return {

--- a/utils/climateDataService.tsx
+++ b/utils/climateDataService.tsx
@@ -106,6 +106,9 @@ export class ClimateDataService {
   }
 
   public getMunicipalities(): Array<Municipality> {
+    if (this.municipalities.length < 1) {
+      throw new Error('No municipalities found')
+    }
     return this.municipalities
   }
 

--- a/utils/companyDataService.tsx
+++ b/utils/companyDataService.tsx
@@ -30,6 +30,9 @@ export class CompanyDataService {
   }
 
   public getCompanies(): Array<Company> {
+    if (this.companies.length < 1) {
+      throw new Error('No companies found')
+    }
     return this.companies
   }
 

--- a/utils/datasetDefinitions.tsx
+++ b/utils/datasetDefinitions.tsx
@@ -5,6 +5,7 @@ import { TOptions } from 'i18next'
 
 import { DataDescriptions, DatasetKey, Municipality } from './types'
 import { normalizeString } from './shared'
+import { defaultDataView, isValidDataView } from '../pages/[dataGroup]/[dataset]/[dataView]'
 
 export const validDatasets = ['utslappen', 'koldioxidbudgetarna', 'klimatplanerna', 'konsumtionen', 'elbilarna', 'laddarna', 'cyklarna', 'upphandlingarna'] as const
 export const defaultDataset: DatasetKey = 'utslappen'
@@ -183,11 +184,33 @@ export function getDataDescriptions(locale: string, t: TFunction) {
   const dataDescriptions = cachedDataDescriptions.get(locale)!
   const validDatasets = new Set(Object.keys(dataDescriptions))
 
-  function isValidDataset(dataset: string): dataset is DatasetKey {
-    return validDatasets.has(normalizeString(dataset))
+  /**
+   * Normalize a dataset key and return it. Fallback to default if input was invalid.
+   */
+  function getDataset(rawDataset: string): DatasetKey {
+    const normalized = normalizeString(rawDataset)
+    if (validDatasets.has(normalized)) {
+      return normalized as DatasetKey
+    }
+
+    return defaultDataset
   }
 
-  return { dataDescriptions, isValidDataset, validDatasets }
+  /**
+   * Normalize a dataView key and return it. Fallback to default if input was invalid.
+   */
+  function getDataView(rawDataView: string) {
+    const normalized = normalizeString(rawDataView)
+    if (isValidDataView(normalized)) {
+      return normalized
+    }
+
+    return defaultDataView
+  }
+
+  return {
+    dataDescriptions, validDatasets, getDataset, getDataView,
+  }
 }
 
 export const dataOnDisplay = (

--- a/utils/shared.ts
+++ b/utils/shared.ts
@@ -1,13 +1,9 @@
-import { defaultDataView, secondaryDataView } from '../pages/[dataGroup]/[dataset]/[dataView]'
-
 export const normalizeString = (input: string) => input.replace('ä', 'a').replace('ö', 'o').replace('å', 'a').toLowerCase()
 
 export const toTitleCase = (str: string) => str.replace(
   /\w\S*/g,
   (txt) => txt.charAt(0).toUpperCase() + txt.slice(1).toLowerCase(),
 )
-
-export const isValidDataView = (dataView: string) => [defaultDataView, secondaryDataView].includes(dataView)
 
 export const replaceLetters = (name: string): string => {
   const replacements: Record<string, string> = {

--- a/utils/shared.ts
+++ b/utils/shared.ts
@@ -19,3 +19,5 @@ export const replaceLetters = (name: string): string => {
 
   return name.replace(regex, (match) => replacements[match])
 }
+
+export const ONE_WEEK_MS = 60 * 60 * 24 * 7


### PR DESCRIPTION
## High level overview
This PR improves the perceived performance when navigating between data groups (companies vs municipalities), among other bugfixes and improvements related to the routing and data loading. Thanks to improved server side caching, data loads faster too, while using less RAM due to reduced duplication in the cache. 

## Most important changes
- Bugfix: Ensure state from URL can control which dataGroup to show by default. This allows linking to the RegionalView again.
- Simplify client-side state and rely on server side state plus link prefetching instead. This reduces the unnecessary re-renders on the client when navigating between different datasets.
- Add caching for municipalities and companies since they are the heavy datasets. Remove response caching since that duplicates data unnecessarily and thus uses more RAM.
- Redirect to default dataset or dataView instead of showing 404 page.
- Fix broken caching for the map API endpoint. This greatly speeds up the time it takes to show the map, even when toggling back and forth between the two views `/lista` and `/karta`.
- Fix hydration warning caused by usage of `t` imported from `i18next` instead of importing `useTranslation` from `next-i18next` and then getting the `t`-function via `const { t } = useTranslation()`.
- Side effect of the caching change: Fixed a bug where translations didn't update properly during dev HMR. This was because the i18n strings got cached together with the other data. Since we now only cache the actual data, and not the full responses, the i18n strings will now always show the latest version (for routes using the dataview / StartPage).


## Remaining tasks
- [x] Improve caching on the server side. Instead of duplicating `companies` and `municipalities` for every valid combination of `dataGroup` and `dataset`, we could cache `municipalities` and `companies`  separately, and then extend the other cached props. This way, we could reduce RAM usage, and improve performance (since we would get more cache hits for getting the companies + municipalities data).

## To solve in a future PR:
- Improve page load performance. We're loading way too much data. See #440 for details.