### PR TITLE
Improve UX for the main menu 

### DIFF
--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -6,17 +6,20 @@ import { useTranslation } from 'next-i18next'
 import { devices } from '../utils/devices'
 
 const HeaderContainer = styled.header`
+  --header-padding: 0.5rem;
+  --btn-size: 2rem;
+
   position: fixed;
   top: 0;
   width: 100%;
   display: flex;
   align-items: center;
-  padding: 8px;
+  padding: var(--header-padding);
   background-color: ${({ theme }) => theme.midGreen};
   z-index: 1000;
 
   @media only screen and (${devices.tablet}) {
-    padding: 16px;
+    --header-padding: 1rem;
   }
 `
 
@@ -56,6 +59,7 @@ const NavigationLink = styled.a`
 const HamburgerMenu = styled.div`
   display: block;
   margin-left: auto;
+  height: var(--btn-size);
 
   @media only screen and (${devices.laptop}) {
     display: none;
@@ -65,6 +69,8 @@ const HamburgerMenu = styled.div`
 const HamburgerButton = styled.button`
   border: none;
   background: transparent;
+  height: var(--btn-size);
+  width: var(--btn-size);
 `
 
 const FullScreenMenu = styled.div`
@@ -73,7 +79,8 @@ const FullScreenMenu = styled.div`
   right: 0;
   width: 100%;
   height: 100%;
-  background-color: ${({ theme }) => theme.midGreen};
+  /* TODO: fix color */
+  background-color: ${({ theme }) => theme.midGreen}10;
   display: flex;
   flex-direction: column;
   z-index: 1000;
@@ -84,13 +91,21 @@ const FullScreenMenu = styled.div`
   }
 `
 
+// TODO: ensure consistent button sizes
+// TODO: fix header height to make it consistent across all screen sizes
+// TODO: ensure consistent hamburger button placement
+
 const CloseButtonContainer = styled.div`
   position: absolute;
-  top: 1rem;
-  right: 1rem;
+  top: var(--header-padding);
+  right: var(--header-padding);
+  height: var(--btn-size);
+  width: var(--btn-size);
 
-  @media only screen and (${devices.tablet}) {
-    top: 1.2rem;
+  & ${HamburgerButton} {
+    display: flex;
+    justify-content: center;
+    align-items: flex-start;
   }
 `
 
@@ -167,13 +182,13 @@ function Header() {
       </NavigationList>
       <HamburgerMenu>
         <HamburgerButton type="button" onClick={() => setMenuOpen(!menuOpen)}>
-          <Image src="/icons/menu.svg" width="30" height="30" alt={t('common:components.Header.menu')} />
+          <Image src="/icons/menu.svg" width="32" height="32" alt={t('common:components.Header.menu')} />
         </HamburgerButton>
         {menuOpen && (
           <FullScreenMenu>
             <CloseButtonContainer>
               <HamburgerButton type="button" onClick={() => setMenuOpen(false)}>
-                <Image src="/icons/close_round.svg" width="20" height="20" alt={t('common:actions.close')} />
+                <Image src="/icons/close_round.svg" width="32" height="32" alt={t('common:actions.close')} />
               </HamburgerButton>
             </CloseButtonContainer>
             <Separator />

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -17,10 +17,6 @@ const HeaderContainer = styled.header`
   padding: var(--header-padding);
   background-color: ${({ theme }) => theme.midGreen};
   z-index: 1000;
-
-  @media only screen and (${devices.tablet}) {
-    --header-padding: 1rem;
-  }
 `
 
 const LogoContainer = styled.div`
@@ -29,6 +25,8 @@ const LogoContainer = styled.div`
   left: 50%;
   transform: translate(-50%, -50%);
   display: flex;
+  height: var(--btn-size);
+  padding-top: 4px;
 `
 
 const NavigationList = styled.ul`
@@ -37,8 +35,10 @@ const NavigationList = styled.ul`
   @media only screen and (${devices.laptop}) {
     list-style: none;
     display: flex;
-    gap: 2rem;
+    gap: 1.5rem;
     margin-left: auto;
+    height: var(--btn-size);
+    align-items: center;
   }
 `
 
@@ -79,21 +79,16 @@ const FullScreenMenu = styled.div`
   right: 0;
   width: 100%;
   height: 100%;
-  /* TODO: fix color */
-  background-color: ${({ theme }) => theme.midGreen}10;
+  background-color: ${({ theme }) => theme.midGreen};
   display: flex;
   flex-direction: column;
   z-index: 1000;
   padding: 3rem 1rem 1rem 1rem;
 
   @media only screen and (${devices.tablet}) {
-    padding-top: 4rem;
+    padding-top: 3rem;
   }
 `
-
-// TODO: ensure consistent button sizes
-// TODO: fix header height to make it consistent across all screen sizes
-// TODO: ensure consistent hamburger button placement
 
 const CloseButtonContainer = styled.div`
   position: absolute;
@@ -167,7 +162,7 @@ function Header() {
           <Image
             src="/logos/klimatkollen_logo_black.svg"
             width="150"
-            height="30"
+            height="32"
             alt="Klimatkollen logotyp"
           />
         </LogoContainer>

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -11,12 +11,12 @@ const HeaderContainer = styled.header`
   width: 100%;
   display: flex;
   align-items: center;
-  padding: 16px;
+  padding: 8px;
   background-color: ${({ theme }) => theme.midGreen};
   z-index: 1000;
 
-  @media only screen and (${devices.mobile}) {
-    padding: 8px;
+  @media only screen and (${devices.tablet}) {
+    padding: 16px;
   }
 `
 

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import React, { useEffect, useState } from 'react'
 import styled from 'styled-components'
 import Image from 'next/image'
 import Link from 'next/link'
@@ -124,6 +124,18 @@ type NavItem = {
 function Header() {
   const [menuOpen, setMenuOpen] = useState(false)
   const { t } = useTranslation()
+
+  useEffect(() => {
+    const closeMenuListener = (event: KeyboardEvent) => {
+      if (menuOpen && event.key === 'Escape') {
+        setMenuOpen(false)
+      }
+    }
+
+    window.addEventListener('keydown', closeMenuListener)
+
+    return () => window.removeEventListener('keydown', closeMenuListener)
+  }, [menuOpen, setMenuOpen])
 
   const navigationItems: NavItem[] = [
     { href: '/kallor-och-metod', label: t('common:components.Header.method') },

--- a/components/ToggleButton.tsx
+++ b/components/ToggleButton.tsx
@@ -25,10 +25,10 @@ const ToggleBtn = styled.button`
 
 const ToggleText = styled.p`
   margin-right: 8px;
-  font-size: 14px;
+  font-size: 12px;
   font-family: 'Borna';
-  @media only screen and (${devices.mobile}) {
-    font-size: 12px;
+  @media only screen and (${devices.tablet}) {
+    font-size: 14px;
   }
 `
 

--- a/utils/devices.ts
+++ b/utils/devices.ts
@@ -1,13 +1,11 @@
 const deviceSizesPx = {
   smallMobile: 375,
-  mobile: 767,
   tablet: 768,
   laptop: 1440,
 }
 
 const devices = {
   smallMobile: `min-width: ${deviceSizesPx.smallMobile}px`,
-  mobile: `max-width: ${deviceSizesPx.mobile}px`,
   tablet: `min-width: ${deviceSizesPx.tablet}px`,
   laptop: `min-width: ${deviceSizesPx.laptop}px`,
 }

--- a/utils/devices.ts
+++ b/utils/devices.ts
@@ -1,7 +1,7 @@
 const deviceSizesPx = {
   smallMobile: 375,
   tablet: 768,
-  laptop: 1440,
+  laptop: 1024,
 }
 
 const devices = {


### PR DESCRIPTION
Fix #549 
Fix #562 

- Ensure consistent header height for all screen sizes. This in turn fixes the scroll padding used for navigating to anchor links, and account for the fixed header.
- Ensure consistent positioning for the hamburger menu button. They are now always positioned on top of each other.
- Improve breakpoints and simplify so we only have one approach (min-width), to make it easy to design for mobile first.
- Allow pressing the Escape key to close the hamburger menu on desktop devices.
- Show the desktop navigation menu earlier (at 1024px instead of at 1440px). This gives a better experience for laptop/desktop users.
- Improve vertical alignment for klimatkollen logo to feel visually centered.