### PR TITLE
Remove old pulbic data file, and remove use of replaceLetters()

### DIFF
--- a/components/Map/Map.tsx
+++ b/components/Map/Map.tsx
@@ -12,7 +12,6 @@ import { deviceSizesPx, onTouchDevice } from '../../utils/devices'
 import {
   MapProps, MunicipalityTapInfo, MunicipalityData,
 } from '../../utils/types'
-import { replaceLetters } from '../../utils/shared'
 
 const INITIAL_VIEW_STATE = {
   longitude: 17.062927,
@@ -118,7 +117,7 @@ export function isMunicipalityData(
 function MobileTooltip({ tInfo }: { tInfo: MunicipalityTapInfo }) {
   return (
     <Link
-      href={`/kommun/${replaceLetters(tInfo.mData.name).toLowerCase()}`}
+      href={`/kommun/${tInfo.mData.name.toLowerCase()}`}
       style={{
         ...TOOLTIP_MOBILE_STYLE,
         left: tInfo.x,
@@ -201,8 +200,7 @@ function Map({
   }, [wrapperRef])
 
   const municipalityLines = municipalityFeatureCollection?.features?.flatMap(
-    ({ geometry, properties }: { geometry: any; properties: any }) => {
-      const name = replaceLetters(properties.name)
+    ({ geometry, properties: { name } }: { geometry: any; properties: { name: string } }) => {
       const currentMunicipality = data.find((e) => e.name === name)
       const dataPoint = currentMunicipality?.primaryDataPoint
       const formattedDataPoint = currentMunicipality?.formattedPrimaryDataPoint
@@ -279,7 +277,7 @@ function Map({
             setLastTapInfo({ x, y, mData }) // trigger mobile tooltip display
             return
           }
-          router.push(`/kommun/${replaceLetters(mData.name).toLowerCase()}`)
+          router.push(`/kommun/${mData.name.toLowerCase()}`)
         }}
         onViewStateChange={({ viewState }) => {
           setLastTapInfo(null)

--- a/utils/generateMunipacitySitemap.ts
+++ b/utils/generateMunipacitySitemap.ts
@@ -1,6 +1,5 @@
 import { type TFunction } from 'next-i18next'
 
-import { replaceLetters } from './shared'
 import { Municipality } from './types'
 
 type SiteMap = {
@@ -17,7 +16,7 @@ export const generateMunicipalitySitemapData = ({
 }: {
   municipalities: Municipality[]
 }): SiteMap[] => municipalities.map((m) => ({
-  url: `${BASE_URL}/kommun/${replaceLetters(m.Name).toLowerCase()}`,
+  url: `${BASE_URL}/kommun/${m.Name.toLowerCase()}`,
   name: m.Name,
   lastModified: new Date(),
   changeFrequency: 'yearly',

--- a/utils/shared.ts
+++ b/utils/shared.ts
@@ -5,19 +5,4 @@ export const toTitleCase = (str: string) => str.replace(
   (txt) => txt.charAt(0).toUpperCase() + txt.slice(1).toLowerCase(),
 )
 
-export const replaceLetters = (name: string): string => {
-  const replacements: Record<string, string> = {
-    'Ã¥': 'å',
-    'Ã¤': 'ä',
-    'Ã¶': 'ö',
-    'Ã…': 'Å',
-    'Ã„': 'Ä',
-    'Ã–': 'Ö',
-  }
-
-  const regex = new RegExp(Object.keys(replacements).join('|'), 'g')
-
-  return name.replace(regex, (match) => replacements[match])
-}
-
 export const ONE_WEEK_MS = 60 * 60 * 24 * 7


### PR DESCRIPTION
This can be done because special characters for all names have already been replaced in the data file that is actually used (`pages/data/kommuner.json`).

This will first and foremost reduce confusion (I got confused why we had two kommuner.json in the project). And this will also give a slight performance improvement since we don't need to perform useless operations.

I did a global search for all the special characters that `replaceLetters()` is replacing and confirmed that these characters are no longer present in the project. And if we need this formatting for some reason in the future, we can search the git history, GitHub etc to get the `replaceLetters()` helper back.



## Totally irrelevant now, but might be useful in the future:
Also, here's a script I created because I accidentally worked with the wrong dataset where strings were malformed:

```ts
import { readFile, writeFile } from 'fs/promises'
import { resolve } from 'path'

const file = await readFile(
  resolve(import.meta.dirname, 'municipalities.json'),
  { encoding: 'utf-8' },
)

export const replaceLetters = (name) => {
  const replacements = {
    'Ã¥': 'å',
    'Ã¤': 'ä',
    'Ã¶': 'ö',
    'Ã…': 'Å',
    'Ã„': 'Ä',
    'Ã–': 'Ö',
  }

  const regex = new RegExp(Object.keys(replacements).join('|'), 'g')

  return name.replace(regex, (match) => replacements[match])
}

const formatted = replaceLetters(file)

await writeFile(
  resolve(import.meta.dirname, 'municipalities-formatted.json'),
  JSON.stringify(JSON.parse(formatted), null, 2),
  {
    encoding: 'utf-8',
  },
)

```