### PR TITLE
show map view first (#592)

### DIFF
--- a/pages/[dataGroup]/[dataset]/[dataView]/index.tsx
+++ b/pages/[dataGroup]/[dataset]/[dataView]/index.tsx
@@ -10,8 +10,8 @@ import { getDataDescriptions } from '../../../../utils/datasetDefinitions'
 import { getServerSideI18n } from '../../../../utils/getServerSideI18n'
 import { ONE_WEEK_MS } from '../../../../utils/shared'
 
-export const defaultDataView = 'lista'
-export const secondaryDataView = 'karta'
+export const defaultDataView = 'karta'
+export const secondaryDataView = 'lista'
 export const isValidDataView = (dataView: string) => [defaultDataView, secondaryDataView].includes(dataView)
 
 interface Params extends ParsedUrlQuery {


### PR DESCRIPTION
The municipality site now shows the map view on default. Previously, list view was shown.
