### PR TITLE
Add an issue template for better issues.

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,27 @@
+---
+name: Bug report
+about: Report an bug on klimatkollen.se
+title: ''
+labels: bug
+assignees: ''
+
+---
+
+**Describe the bug**
+A clear and concise description of what you think is wrong with the side, the data, or anything related.
+
+**To Reproduce**
+How can someone else observe the problem? Give concrete steps, e.g.:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/enhancement.md
+++ b/.github/ISSUE_TEMPLATE/enhancement.md
@@ -1,13 +1,13 @@
 ---
-name: Task
+name: Enhancement
 about: An improvement to be made to Klimatkollen
-title: Short summary of the task
+title: Short summary
 labels: ''
 assignees: ''
 
 ---
 
-**Describe the task**
+**Description**
 What would you like to be done?
 
 **Definition of Done**

--- a/.github/ISSUE_TEMPLATE/enhancement.md
+++ b/.github/ISSUE_TEMPLATE/enhancement.md
@@ -10,6 +10,9 @@ assignees: ''
 **Description**
 What would you like to be done?
 
+**Motivation**
+What goals for klimatkollen would this help achieve?
+
 **Definition of Done**
 Clarify how one can tell that the issue is completed. What behavior is in place / how does the code or data look like?
 

--- a/.github/ISSUE_TEMPLATE/task.md
+++ b/.github/ISSUE_TEMPLATE/task.md
@@ -1,0 +1,27 @@
+---
+name: Task
+about: An improvement to be made to Klimatkollen
+title: Short summary of the task
+labels: ''
+assignees: ''
+
+---
+
+**Describe the task**
+What would you like to be done?
+
+**Definition of Done**
+Clarify how one can tell that the issue is completed. What behavior is in place / how does the code or data look like?
+
+**When should it be done?**
+Is it urgent? Any relevant dates to refer to? Does other work depend on it?
+
+**Contact person**
+Who can answer questions about the implementation?
+
+In addition to the Definition of Done, the following always apply:
+ - Tests, building, and linting passes
+ - No new warnings are introduced
+ - User experience is not reduced
+ - Code is well formatted and readable
+See doc/contributing.md.


### PR DESCRIPTION
I Identified two kinds - Task and Bug Report. I hope these suggestion questions should help issue authors more clearly express their expectations, and leave more helpful information for those that take the issues up. Let me know if you think the questions included are decent, or if you'd like to suggest some alternatives. 