### PR TITLE
Fix/only show climateplan link for actual links

### DIFF
--- a/components/FactSection.tsx
+++ b/components/FactSection.tsx
@@ -64,13 +64,16 @@ type Props = {
   heading: string
   data: string
   info?: string
+  className?: string
 }
 
-function FactSection({ heading, data, info }: Props) {
+function FactSection({
+  heading, data, info, className,
+}: Props) {
   const [open, setOpen] = useState(false)
 
   return (
-    <details onToggle={(event) => setOpen((event.target as HTMLDetailsElement).open)}>
+    <details onToggle={(event) => setOpen((event.target as HTMLDetailsElement).open)} className={className}>
       <Row>
         <SectionLeft>
           <InfoHeading>{heading}</InfoHeading>

--- a/components/Municipality/MunicipalityScorecard.tsx
+++ b/components/Municipality/MunicipalityScorecard.tsx
@@ -1,5 +1,6 @@
 import styled from 'styled-components'
 import { useTranslation } from 'next-i18next'
+import Link from 'next/link'
 
 import ScorecardSection from './ScorecardSection'
 import { ClimatePlan } from '../../utils/types'
@@ -61,7 +62,7 @@ const ArrowIcon = styled(Icon)`
   fill: ${({ theme }) => theme.newColors.black3};
 `
 
-const LinkButton = styled.button`
+const LinkButton = styled(Link)`
   height: 36px;
   color: ${({ theme }) => theme.newColors.black3};
   background: ${({ theme }) => theme.newColors.blue2};
@@ -118,16 +119,11 @@ function Scorecard({
   climatePlan,
 }: Props) {
   const { t } = useTranslation()
-  const climatePlanYearFormatted = climatePlan.YearAdapted !== climatePlanMissing
+  const hasClimatePlan = climatePlan.Link !== climatePlanMissing
+  const climatePlanYearFormatted = hasClimatePlan
     ? t('municipality:facts.climatePlan.adaptedYear', { year: climatePlan.YearAdapted })
     : climatePlan.YearAdapted
   const politicalRuleFormatted = politicalRule ? politicalRule.join(', ') : t('common:dataMissing')
-
-  const handleButtonClick = () => {
-    if (climatePlan.Link !== climatePlanMissing) {
-      window.open(climatePlan.Link, '_blank')
-    }
-  }
 
   return (
     <StyledDiv>
@@ -140,9 +136,9 @@ function Scorecard({
             <PlanIcon />
             <H5>{t('municipality:facts.climatePlan.title')}</H5>
           </SectionLeft>
-          {climatePlan.Link !== climatePlanMissing ? (
+          {hasClimatePlan ? (
             <SectionRight>
-              <LinkButton onClick={handleButtonClick}>
+              <LinkButton href={climatePlan.Link} target="_blank">
                 {t('common:actions.open')}
                 <Square>
                   <ArrowIcon />

--- a/components/Municipality/MunicipalityScorecard.tsx
+++ b/components/Municipality/MunicipalityScorecard.tsx
@@ -29,6 +29,10 @@ const GreyContainer = styled.div`
   border-radius: 8px;
   padding: 16px 16px 0 16px;
   margin-bottom: 8px;
+
+  .no-climate-plan h3 {
+    color: ${({ theme }) => theme.newColors.orange3};
+  }
 `
 
 const Row = styled.div`
@@ -151,6 +155,7 @@ function Scorecard({
           heading={climatePlanYearFormatted}
           data=""
           info={t('municipality:facts.climatePlan.info', { comment: climatePlan.Comment })}
+          className={!hasClimatePlan ? 'no-climate-plan' : undefined}
         />
       </GreyContainer>
       {rank && (

--- a/components/Municipality/MunicipalityScorecard.tsx
+++ b/components/Municipality/MunicipalityScorecard.tsx
@@ -77,6 +77,7 @@ const LinkButton = styled(Link)`
   display: flex;
   align-items: center;
   justify-content: center;
+  text-decoration: none;
   &:hover {
     background: ${({ theme }) => theme.newColors.blue1};
   }

--- a/components/Municipality/MunicipalityScorecard.tsx
+++ b/components/Municipality/MunicipalityScorecard.tsx
@@ -1,4 +1,4 @@
-import styled, { css } from 'styled-components'
+import styled from 'styled-components'
 import { useTranslation } from 'next-i18next'
 
 import ScorecardSection from './ScorecardSection'
@@ -34,6 +34,7 @@ const Row = styled.div`
   display: flex;
   flex-direction: row;
   justify-content: space-between;
+  height: 36px;
 `
 
 const SectionLeft = styled.section`
@@ -77,21 +78,6 @@ const LinkButton = styled.button`
   & a {
     text-decoration: none;
   }
-  ${({ disabled }) => disabled
-    && css`
-      color: ${({ theme }) => theme.newColors.black3};
-      background: ${({ theme }) => theme.newColors.blue3};
-      cursor: not-allowed;
-
-      /* Remove hover effect */
-      &:hover {
-        background: ${({ theme }) => theme.newColors.blue3};
-      }
-
-      & ${ArrowIcon} {
-        fill: ${({ theme }) => theme.newColors.black3};
-      }
-    `}
 `
 
 const Square = styled.div`
@@ -154,17 +140,16 @@ function Scorecard({
             <PlanIcon />
             <H5>{t('municipality:facts.climatePlan.title')}</H5>
           </SectionLeft>
-          <SectionRight>
-            <LinkButton
-              onClick={handleButtonClick}
-              disabled={climatePlan.Link === climatePlanMissing}
-            >
-              {t('common:actions.open')}
-              <Square>
-                <ArrowIcon />
-              </Square>
-            </LinkButton>
-          </SectionRight>
+          {climatePlan.Link !== climatePlanMissing ? (
+            <SectionRight>
+              <LinkButton onClick={handleButtonClick}>
+                {t('common:actions.open')}
+                <Square>
+                  <ArrowIcon />
+                </Square>
+              </LinkButton>
+            </SectionRight>
+          ) : null}
         </Row>
         <FactSection
           heading={climatePlanYearFormatted}


### PR DESCRIPTION
NOTE: Not sure if this should be merged into #593 or if we merge this later, and then into staging.

- Show climate plan LinkButton only if there's an actual climate plan link.
- Also highlight missing climate plans with distinctive color to make that point clear.

Here's the result of both changes. Tested with Åre kommun since they don't have a climate plan yet (in this dataset).

![image](https://github.com/Klimatbyran/klimatkollen/assets/6125097/1cac948d-0e92-48ce-8eb5-66dd3b64e3a0)
