### PR TITLE
Fairly represent the spread of values for the emission map by improving the boundaries.

### DIFF
--- a/public/locales/sv/common.json
+++ b/public/locales/sv/common.json
@@ -78,7 +78,7 @@
     "municipalityEmissions": {
       "body": "Genomsnittlig årlig förändring av koldioxidutsläppen i Sveriges kommuner sedan Parisavtalet 2015.",
       "columnHeader": "Utsläppsförändring",
-      "labels": ["0% +", "0–1%", "1–2%", "2–5%", "5–10%", "10–15%"],
+      "labels": ["0% +", "0–3%", "3–5%", "5–7%", "7–10%", "10–15%"],
       "name": "Utsläppen",
       "source": "Källa: [Nationella emissionsdatabasen](https://nationellaemissionsdatabasen.smhi.se/)",
       "title": "Utsläppsförändring"

--- a/utils/datasetDefinitions.tsx
+++ b/utils/datasetDefinitions.tsx
@@ -38,7 +38,7 @@ function getTranslatedDataDescriptions(locale: string, _t: TFunction): DataDescr
       title: t('common:datasets.municipalityEmissions.title'),
       body: t('common:datasets.municipalityEmissions.body'),
       source: t('common:datasets.municipalityEmissions.source'),
-      boundaries: [0.0, -0.01, -0.02, -0.05, -0.1],
+      boundaries: [0.0, -0.03, -0.05, -0.07, -0.1],
       labels: t('common:datasets.municipalityEmissions.labels', { returnObjects: true }) as unknown as string[],
       labelRotateUp: [true, false, false, false, false, false],
       columnHeader: t('common:datasets.municipalityEmissions.columnHeader'),


### PR DESCRIPTION
Make the emission reduction colors more representative for the actual state of (serious lack of) emission reductions. Also use even numeric spans between the boundary values, to make the scale show the spread of values instead of heavily skewing towards grouping most municipalities in the later ranges.

The emissions map for municipalities was previously completely misrepresenting the data, and minimizing how serious the gap is between what is needed and what has happened so far.

The old map used the ranges `0, 0-1%, 1-2%, 2-5%, 5-10% and 10-15%`. This made most municipalities with far too low emission reductions to show up in the 2-5% or 5-10% ranges, when they color-wise actually should end up in the first ranges to match if their emissions reductions are enough or not. This might look good on the map, but is a completely unfair representation of the data. It completely hides the fact that most municipalities have far too slow emission reductions to stay within their emission budgets.

**Do you think this is unfair and alarmistic to have this much red, compared to how the map looked before?** Then please look at the carbon budgets for municipalities, and see that this change actually makes the colors representing emission reductions to align much better with the colors for how (bad) municipalities are following their carbon budgets.