### PR TITLE
added CLI params to control outfile and percentage value calc

### DIFF
--- a/data/climate_data_calculations.py
+++ b/data/climate_data_calculations.py
@@ -1,6 +1,9 @@
 # -*- coding: utf-8 -*-
 
+import argparse
 import json
+
+import pandas as pd
 
 from solutions.cars.electric_car_change_rate import get_electric_car_change_rate
 from solutions.cars.electric_vehicle_per_charge_points import (
@@ -16,67 +19,87 @@ from issues.consumption.consumption_data_calculations import get_consumption_emi
 # Notebook from ClimateView that our calculations are based on:
 # https://colab.research.google.com/drive/1qqMbdBTu5ulAPUe-0CRBmFuh8aNOiHEb?usp=sharing
 
+def create_dataframe(to_percentage: bool) -> pd.DataFrame:
+    # Get emission calculations
+    df = get_municipalities()
+    print('1. Municipalities loaded and prepped')
 
-# Get emission calculations
-df = get_municipalities()
-print('1. Municipalities loaded and prepped')
+    df = emission_calculations(df)
+    print('2. Climate data and calculations added')
 
-df = emission_calculations(df)
-print('2. Climate data and calculations added')
+    df = get_electric_car_change_rate(df, to_percentage)
+    print('3. Hybrid car data and calculations added')
 
-df = get_electric_car_change_rate(df)
-print('3. Hybrid car data and calculations added')
+    df = get_climate_plans(df)
+    print('4. Climate plans added')
 
-df = get_climate_plans(df)
-print('4. Climate plans added')
+    df = bicycle_calculations(df)
+    print('5. Bicycle data added')
 
-df = bicycle_calculations(df)
-print('5. Bicycle data added')
+    df = get_consumption_emissions(df)
+    print('6. Consumption emission data added')
 
-df = get_consumption_emissions(df)
-print('6. Consumption emission data added')
+    df_evpc = get_electric_vehicle_per_charge_points()
+    df = df.merge(df_evpc, on='Kommun', how='left')
+    print('7. CPEV for December 2023 added')
 
-df_evpc = get_electric_vehicle_per_charge_points()
-df = df.merge(df_evpc, on='Kommun', how='left')
-print('7. CPEV for December 2023 added')
+    df_procurements = get_procurement_data()
+    df = df.merge(df_procurements, on='Kommun', how='left')
+    print('8. Climate requirements in procurements added')
 
-df_procurements = get_procurement_data()
-df = df.merge(df_procurements, on='Kommun', how='left')
-print('8. Climate requirements in procurements added')
+    return df
 
-numeric_columns = [col for col in df.columns if str(col).isdigit()]
 
-temp = [
-    {
-        'kommun': df.iloc[i]['Kommun'],
-        'län': df.iloc[i]['Län'],
-        'emissions': { str(year): df.iloc[i][year] for year in numeric_columns },
-        'budget': df.iloc[i]['Budget'],
-        'emissionBudget': df.iloc[i]['parisPath'],
-        'approximatedHistoricalEmission': df.iloc[i]['approximatedHistorical'],
-        'totalApproximatedHistoricalEmission': df.iloc[i]['totalApproximatedHistorical'],
-        'trend': df.iloc[i]['trend'],
-        'trendEmission': df.iloc[i]['trendEmission'],
-        'historicalEmissionChangePercent': df.iloc[i]['historicalEmissionChangePercent'],
-        'neededEmissionChangePercent': df.iloc[i]['neededEmissionChangePercent'],
-        'hitNetZero': df.iloc[i]['hitNetZero'],
-        'budgetRunsOut': df.iloc[i]['budgetRunsOut'],
-        'electricCarChangePercent': df.iloc[i]['electricCarChangePercent'],
-        'electricCarChangeYearly': df.iloc[i]['electricCarChangeYearly'],
-        'climatePlanLink': df.iloc[i]['Länk till aktuell klimatplan'],
-        'climatePlanYear': df.iloc[i]['Antagen år'],
-        'climatePlanComment': df.iloc[i]['Namn, giltighetsår, kommentar'],
-        'bicycleMetrePerCapita': df.iloc[i]['metrePerCapita'],
-        'totalConsumptionEmission': df.iloc[i]['Total emissions'],
-        'electricVehiclePerChargePoints': df.iloc[i]['EVPC'],
-        'procurementScore': df.iloc[i]['procurementScore'],
-        'procurementLink': df.iloc[i]['procurementLink'],
-    }
-    for i in range(len(df))
-]
+def convert_df_to_dict(df: pd.DataFrame, numeric_columns: list) -> dict:
+    temp = [
+        {
+            'kommun': df.iloc[i]['Kommun'],
+            'län': df.iloc[i]['Län'],
+            'emissions': { str(year): df.iloc[i][year] for year in numeric_columns },
+            'budget': df.iloc[i]['Budget'],
+            'emissionBudget': df.iloc[i]['parisPath'],
+            'approximatedHistoricalEmission': df.iloc[i]['approximatedHistorical'],
+            'totalApproximatedHistoricalEmission': df.iloc[i]['totalApproximatedHistorical'],
+            'trend': df.iloc[i]['trend'],
+            'trendEmission': df.iloc[i]['trendEmission'],
+            'historicalEmissionChangePercent': df.iloc[i]['historicalEmissionChangePercent'],
+            'neededEmissionChangePercent': df.iloc[i]['neededEmissionChangePercent'],
+            'hitNetZero': df.iloc[i]['hitNetZero'],
+            'budgetRunsOut': df.iloc[i]['budgetRunsOut'],
+            'electricCarChangePercent': df.iloc[i]['electricCarChangePercent'],
+            'electricCarChangeYearly': df.iloc[i]['electricCarChangeYearly'],
+            'climatePlanLink': df.iloc[i]['Länk till aktuell klimatplan'],
+            'climatePlanYear': df.iloc[i]['Antagen år'],
+            'climatePlanComment': df.iloc[i]['Namn, giltighetsår, kommentar'],
+            'bicycleMetrePerCapita': df.iloc[i]['metrePerCapita'],
+            'totalConsumptionEmission': df.iloc[i]['Total emissions'],
+            'electricVehiclePerChargePoints': df.iloc[i]['EVPC'],
+            'procurementScore': df.iloc[i]['procurementScore'],
+            'procurementLink': df.iloc[i]['procurementLink'],
+        }
+        for i in range(len(df))
+    ]
+    return temp
 
-with open('output/climate-data.json', 'w', encoding='utf8') as json_file:
-    # save dataframe as json file
-    json.dump(temp, json_file, ensure_ascii=False, default=str)
 
-print('Climate data JSON file created and saved')
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description="Climate data calculations")
+    parser.add_argument("-o", "--outfile", default="output/climate-data.json", type=str, help="Output filename (JSON formatted)")
+    parser.add_argument("-t", "--to_percentage", action="store_true", default=False, help="Convert to percentages")
+
+    args = parser.parse_args()
+
+    df = create_dataframe(args.to_percentage)
+
+    # Save dataframe as JSON file
+    numeric_columns = [col for col in df.columns if str(col).isdigit()]
+
+    temp = convert_df_to_dict(df, numeric_columns)
+
+    output_file = args.outfile
+
+    with open(output_file, 'w', encoding='utf8') as json_file:
+        # save dataframe as json file
+        json.dump(temp, json_file, ensure_ascii=False, default=str)
+
+    print('Climate data JSON file created and saved')

--- a/data/solutions/cars/electric_car_change_rate.py
+++ b/data/solutions/cars/electric_car_change_rate.py
@@ -5,7 +5,7 @@ import pandas as pd
 PATH_CARS_DATA = "solutions/cars/sources/kpi1_calculations.xlsx"
 
 
-def get_electric_car_change_rate(df):
+def get_electric_car_change_rate(df, to_percent: bool = False):
     # LOAD AND PREP DATA ON CHANGE RATE OF PERCENTAGE OF NEWLY REGISTERED RECHARGABLE CARS PER MUNICIPALITY AND YEAR
     df_raw_cars = pd.read_excel(PATH_CARS_DATA)
 
@@ -15,11 +15,11 @@ def get_electric_car_change_rate(df):
 
     df_raw_cars["electricCarChangePercent"] = df_raw_cars[
         "Procentenheter förändring av andel laddbara bilar 2015-2022"
-    ]
+    ] * (100 if to_percent else 1)
     
     years = [2015, 2016, 2017, 2018, 2019, 2020, 2021, 2022]
     df_raw_cars["electricCarChangeYearly"] = df_raw_cars.apply(
-        lambda x: {year: x.loc[year] for year in years},
+        lambda x: {year: x.loc[year] * (100 if to_percent else 1) for year in years},
         axis=1
     )
 


### PR DESCRIPTION
Added command line parameter to climate_data_calculation.py to enable calculation of percentage values for the electric vehicle metrics. If '-t' is passed, then values will be converted to percentages (instead of 0.072, the number will be 7.2). An -o parameter was also added to specify the output filename. If -t is omitted, the original value is kept. If -o is omitted the default filename is output/climate_data.json.