### PR TITLE
WIP: Data loading, routing, components and types for company details page

### DIFF
--- a/components/Company/Company.tsx
+++ b/components/Company/Company.tsx
@@ -73,6 +73,7 @@ function Company(props: Props) {
         </StyledContainer>
       </PageWrapper>
       <PageWrapper>
+        {/* TODO: Show comment high up on the page */}
         <Bottom>
           <CompanyFacts
             company={company}

--- a/components/Company/Company.tsx
+++ b/components/Company/Company.tsx
@@ -1,0 +1,93 @@
+import styled from 'styled-components'
+import { useTranslation } from 'next-i18next'
+
+import { H1NoPad, ParagraphBold } from '../Typography'
+import BackArrow from '../BackArrow'
+import PageWrapper from '../PageWrapper'
+// import DropDown from '../DropDown'
+import { GuessedCompany, Company as TCompany } from '../../utils/types'
+import CompanyFacts from './CompanyFacts'
+
+const StyledContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  margin-bottom: 48px;
+`
+
+const HeaderSection = styled.div`
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  align-items: center;
+  margin-top: 10px;
+`
+
+const Bottom = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 3rem;
+`
+
+const DropDownSection = styled.div`
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  margin-top: 30px;
+  text-align: center;
+  align-items: center;
+  padding-bottom: 6rem;
+`
+
+type Props = {
+  id: string
+  company: { verified: TCompany, guessed: GuessedCompany }
+  companyNames: Array<string>
+}
+
+function Company(props: Props) {
+  const {
+    id,
+    company,
+    // TODO: Provide a list of company names to allow searching and navigating to other pages
+    companyNames,
+  } = props
+
+  // NOTE: Temporary log to supress ts errors
+  if (!id && !companyNames) {
+    throw new Error('temporary to supress ts errors')
+  }
+
+  const { t } = useTranslation()
+
+  return (
+    <>
+      <PageWrapper>
+        <StyledContainer>
+          <HeaderSection>
+            <BackArrow route="/foretag/utslappen/lista" />
+            <H1NoPad>{company.verified.Name}</H1NoPad>
+            <span>{/* HACK: Only for temporary layout */}</span>
+          </HeaderSection>
+        </StyledContainer>
+      </PageWrapper>
+      <PageWrapper>
+        <Bottom>
+          <CompanyFacts
+            company={company}
+          />
+        </Bottom>
+        <DropDownSection>
+          <ParagraphBold>{t('company:otherCompanies')}</ParagraphBold>
+          {/* <DropDown
+            municipalitiesName={municipalitiesName}
+            placeholder={t('municipality:select')}
+          /> */}
+        </DropDownSection>
+      </PageWrapper>
+    </>
+  )
+}
+
+export default Company

--- a/components/Company/CompanyFacts.tsx
+++ b/components/Company/CompanyFacts.tsx
@@ -1,0 +1,154 @@
+import styled from 'styled-components'
+import { useTranslation } from 'next-i18next'
+import Link from 'next/link'
+
+import ScorecardSection from './ScorecardSection'
+import { H4, H5 } from '../Typography'
+import Icon from '../../public/icons/boxedArrow.svg'
+import PlanIcon from '../../public/icons/climatePlan.svg'
+import FactSection from '../FactSection'
+import Markdown from '../Markdown'
+import { Company as TCompany, GuessedCompany } from '../../utils/types'
+
+const StyledDiv = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  margin-bottom: 64px;
+`
+
+const StyledH4 = styled(H4)`
+  margin-top: 32px;
+  margin-bottom: 32px;
+  width: 100%;
+`
+
+const GreyContainer = styled.div`
+  background: ${({ theme }) => theme.newColors.black2};
+  border-radius: 8px;
+  padding: 16px 16px 0 16px;
+  margin-bottom: 8px;
+
+  .no-climate-plan h3 {
+    color: ${({ theme }) => theme.newColors.orange3};
+  }
+`
+
+const Row = styled.div`
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  height: 36px;
+`
+
+const SectionLeft = styled.section`
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  width: 90%;
+`
+
+const SectionRight = styled.section`
+  text-align: right;
+`
+
+const ArrowIcon = styled(Icon)`
+  width: 32px;
+  height: 32px;
+  position: absolute;
+  z-index: 1;
+  margin: auto;
+  left: 0;
+  right: 0;
+  top: 0;
+  bottom: 0;
+  fill: ${({ theme }) => theme.newColors.black3};
+`
+
+const LinkButton = styled(Link)`
+  height: 36px;
+  color: ${({ theme }) => theme.newColors.black3};
+  background: ${({ theme }) => theme.newColors.blue2};
+  border-radius: 4px;
+  border: 1px solid transparent;
+  padding: 0.8rem 1rem 0.8rem 0.8rem;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  text-decoration: none;
+  &:hover {
+    background: ${({ theme }) => theme.newColors.blue1};
+  }
+  & a {
+    text-decoration: none;
+  }
+`
+
+const Square = styled.div`
+  width: 16px;
+  height: 16px;
+  position: relative;
+  border-radius: 4px;
+`
+
+type Props = {
+  company: { verified: TCompany, guessed: GuessedCompany }
+}
+
+const formatter = new Intl.NumberFormat('sv-SE', { maximumSignificantDigits: 8 })
+const fractionFormatter = new Intl.NumberFormat('sv-SE', { maximumFractionDigits: 1 })
+
+function CompanyFacts({
+  company,
+}: Props) {
+  const { t } = useTranslation()
+
+  return (
+    <StyledDiv>
+      <StyledH4>
+        {t('company:facts.title', { name: company.verified.Name })}
+      </StyledH4>
+      {/* <GreyContainer>
+        <Row>
+          <SectionLeft>
+            <PlanIcon />
+            <H5>{t('municipality:facts.climatePlan.title')}</H5>
+          </SectionLeft>
+          {/ * TODO: Link to original report * /}
+          {/ * {hasClimatePlan ? (
+            <SectionRight>
+              <LinkButton href={climatePlan.Link} target="_blank">
+                {t('common:actions.open')}
+                <Square>
+                  <ArrowIcon />
+                </Square>
+              </LinkButton>
+            </SectionRight>
+          ) : null} * /}
+        </Row>
+        {/ * TODO: Maybe show the company comment here instead * /}
+        {/ * <FactSection
+          heading={climatePlanYearFormatted}
+          data=""
+          info={t('municipality:facts.climatePlan.info', { comment: climatePlan.Comment })}
+          className={!hasClimatePlan ? 'no-climate-plan' : undefined}
+        /> * /}
+      </GreyContainer> */}
+
+      <ScorecardSection
+        heading="Egna utsläpp"
+        data={formatter.format(company.verified.Emissions.Scope1n2 as unknown as number)}
+        info="Scope 1 och 2"
+      />
+      <ScorecardSection
+        heading="I värdekedjan"
+        data={formatter.format(company.verified.Emissions.Scope3 as unknown as number)}
+        info="Scope 3"
+      />
+
+    </StyledDiv>
+  )
+}
+
+export default CompanyFacts

--- a/components/Company/CompanyFacts.tsx
+++ b/components/Company/CompanyFacts.tsx
@@ -1,13 +1,13 @@
 import styled from 'styled-components'
 import { useTranslation } from 'next-i18next'
-import Link from 'next/link'
+// import Link from 'next/link'
 
 import ScorecardSection from './ScorecardSection'
-import { H4, H5 } from '../Typography'
-import Icon from '../../public/icons/boxedArrow.svg'
-import PlanIcon from '../../public/icons/climatePlan.svg'
-import FactSection from '../FactSection'
-import Markdown from '../Markdown'
+import { H4 } from '../Typography'
+// import Icon from '../../public/icons/boxedArrow.svg'
+// import PlanIcon from '../../public/icons/climatePlan.svg'
+// import FactSection from '../FactSection'
+// import Markdown from '../Markdown'
 import { Company as TCompany, GuessedCompany } from '../../utils/types'
 
 const StyledDiv = styled.div`
@@ -23,81 +23,81 @@ const StyledH4 = styled(H4)`
   width: 100%;
 `
 
-const GreyContainer = styled.div`
-  background: ${({ theme }) => theme.newColors.black2};
-  border-radius: 8px;
-  padding: 16px 16px 0 16px;
-  margin-bottom: 8px;
+// const GreyContainer = styled.div`
+//   background: ${({ theme }) => theme.newColors.black2};
+//   border-radius: 8px;
+//   padding: 16px 16px 0 16px;
+//   margin-bottom: 8px;
 
-  .no-climate-plan h3 {
-    color: ${({ theme }) => theme.newColors.orange3};
-  }
-`
+//   .no-climate-plan h3 {
+//     color: ${({ theme }) => theme.newColors.orange3};
+//   }
+// `
 
-const Row = styled.div`
-  display: flex;
-  flex-direction: row;
-  justify-content: space-between;
-  height: 36px;
-`
+// const Row = styled.div`
+//   display: flex;
+//   flex-direction: row;
+//   justify-content: space-between;
+//   height: 36px;
+// `
 
-const SectionLeft = styled.section`
-  display: flex;
-  align-items: center;
-  gap: 0.5rem;
-  width: 90%;
-`
+// const SectionLeft = styled.section`
+//   display: flex;
+//   align-items: center;
+//   gap: 0.5rem;
+//   width: 90%;
+// `
 
-const SectionRight = styled.section`
-  text-align: right;
-`
+// const SectionRight = styled.section`
+//   text-align: right;
+// `
 
-const ArrowIcon = styled(Icon)`
-  width: 32px;
-  height: 32px;
-  position: absolute;
-  z-index: 1;
-  margin: auto;
-  left: 0;
-  right: 0;
-  top: 0;
-  bottom: 0;
-  fill: ${({ theme }) => theme.newColors.black3};
-`
+// const ArrowIcon = styled(Icon)`
+//   width: 32px;
+//   height: 32px;
+//   position: absolute;
+//   z-index: 1;
+//   margin: auto;
+//   left: 0;
+//   right: 0;
+//   top: 0;
+//   bottom: 0;
+//   fill: ${({ theme }) => theme.newColors.black3};
+// `
 
-const LinkButton = styled(Link)`
-  height: 36px;
-  color: ${({ theme }) => theme.newColors.black3};
-  background: ${({ theme }) => theme.newColors.blue2};
-  border-radius: 4px;
-  border: 1px solid transparent;
-  padding: 0.8rem 1rem 0.8rem 0.8rem;
-  cursor: pointer;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  text-decoration: none;
-  &:hover {
-    background: ${({ theme }) => theme.newColors.blue1};
-  }
-  & a {
-    text-decoration: none;
-  }
-`
+// const LinkButton = styled(Link)`
+//   height: 36px;
+//   color: ${({ theme }) => theme.newColors.black3};
+//   background: ${({ theme }) => theme.newColors.blue2};
+//   border-radius: 4px;
+//   border: 1px solid transparent;
+//   padding: 0.8rem 1rem 0.8rem 0.8rem;
+//   cursor: pointer;
+//   display: flex;
+//   align-items: center;
+//   justify-content: center;
+//   text-decoration: none;
+//   &:hover {
+//     background: ${({ theme }) => theme.newColors.blue1};
+//   }
+//   & a {
+//     text-decoration: none;
+//   }
+// `
 
-const Square = styled.div`
-  width: 16px;
-  height: 16px;
-  position: relative;
-  border-radius: 4px;
-`
+// const Square = styled.div`
+//   width: 16px;
+//   height: 16px;
+//   position: relative;
+//   border-radius: 4px;
+// `
 
 type Props = {
   company: { verified: TCompany, guessed: GuessedCompany }
 }
 
 const formatter = new Intl.NumberFormat('sv-SE', { maximumSignificantDigits: 8 })
-const fractionFormatter = new Intl.NumberFormat('sv-SE', { maximumFractionDigits: 1 })
+// const fractionFormatter = new Intl.NumberFormat('sv-SE', { maximumFractionDigits: 1 })
 
 function CompanyFacts({
   company,

--- a/components/Company/ScorecardSection.tsx
+++ b/components/Company/ScorecardSection.tsx
@@ -1,0 +1,94 @@
+import styled from 'styled-components'
+import { useState } from 'react'
+
+import Markdown from '../Markdown'
+import IconAdd from '../../public/icons/add_light.svg'
+import IconRemove from '../../public/icons/remove_light.svg'
+import { Paragraph } from '../Typography'
+import { devices } from '../../utils/devices'
+
+const BorderContainer = styled.details`
+  padding: 8px 0;
+  border-bottom: 1px solid ${({ theme }) => theme.newColors.blue3};
+`
+
+const Row = styled.summary`
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  align-items: center;
+  gap: 4px;
+  cursor: pointer;
+  list-style: none; /* remove default arrow in Firefox */
+  &::-webkit-details-marker {
+    display: none; /* remove default arrow in Chrome */
+  }
+`
+
+const InfoParagraph = styled(Paragraph)`
+  margin: 16px 0 0 0;
+  font-size: 12px;
+
+  @media only screen and (${devices.tablet}) {
+    font-size: 13px;
+  }
+`
+
+const StyledParagraph = styled(Paragraph)`
+  font-size: 14px;
+  flex: 1;
+
+  @media only screen and (${devices.tablet}) {
+    font-size: 16px;
+  }
+`
+
+const SectionRight = styled.div`
+  text-align: right; 
+`
+
+const StyledIcon = styled.div`
+  margin-left: 16px;
+  color: ${({ theme }) => theme.newColors.blue3};
+
+  &:hover {
+    cursor: pointer;
+  }
+`
+
+type Props = {
+  heading: string
+  data: string
+  info?: string
+}
+
+// TODO: Maybe use similar component for both municipalities and companies
+
+function ScorecardSection({ heading, data, info }: Props) {
+  const [toggle, setToggle] = useState(false)
+
+  const onToggle = () => setToggle(!toggle)
+
+  return (
+    <BorderContainer onToggle={onToggle}>
+      <Row>
+        <StyledParagraph>{heading}</StyledParagraph>
+        <StyledParagraph>{data}</StyledParagraph>
+        {info && (
+        <SectionRight>
+          <StyledIcon>
+            {toggle ? <IconRemove /> : <IconAdd />}
+          </StyledIcon>
+        </SectionRight>
+        )}
+      </Row>
+      {toggle ? (
+        <Markdown components={{ p: InfoParagraph }}>
+          {info}
+        </Markdown>
+      ) : null}
+    </BorderContainer>
+  )
+}
+
+export default ScorecardSection

--- a/components/DropDown.tsx
+++ b/components/DropDown.tsx
@@ -113,6 +113,8 @@ export function search(query: string, municipalitiesName: Array<string>) {
     })
 }
 
+// TODO: Replace with accessible component underneath the hood.
+// TODO: Rewrite props and component body to use `items` rather than `municipalities` specifically.
 function DropDown({ municipalitiesName, placeholder }: Props) {
   const sortedMunicipalities = getSortedMunicipalities(municipalitiesName)
   const [showDropDown, setShowDropDown] = useState(false)
@@ -140,6 +142,7 @@ function DropDown({ municipalitiesName, placeholder }: Props) {
     }
   }, [showDropDown])
 
+  // TODO: Allow passing the callback in via props to allow component to be used for multiple purposes
   const onMunicipalityClick = (name: string) => {
     setSelectedMunicipality(name)
     setShowDropDown(false)
@@ -160,6 +163,8 @@ function DropDown({ municipalitiesName, placeholder }: Props) {
     setMunicipalities(filteredMunicipalities)
   }
 
+  // TODO: unify this with onMunicipalityClick
+  // IDEA: Instead call the callback prop `onItemSelected(item: string)` or just `onSelect(item: string)`
   const seeMunicipality = () => {
     const municipalityExists = municipalities.find(
       (municipality) => municipality.toLowerCase() === selectedMunicipality.toLowerCase(),
@@ -207,6 +212,7 @@ function DropDown({ municipalitiesName, placeholder }: Props) {
           )}
         </SearchDropDown>
       </Container>
+      {/* TODO: translate text and maybe improve the UX by showing it in a different way */}
       {showInfoText && <ErrorText>Välj en kommun i listan</ErrorText>}
     </div>
   )

--- a/pages/[dataGroup]/[dataset]/[dataView]/index.tsx
+++ b/pages/[dataGroup]/[dataset]/[dataView]/index.tsx
@@ -27,7 +27,7 @@ function getCompanies() {
   const cached = cache.get('companies')
   if (cached) return cached
 
-  const companies = new CompanyDataService().getCompanies()
+  const companies = new CompanyDataService().getVerifiedCompanies()
   cache.set('companies', companies)
   return companies
 }

--- a/pages/foretag/[companyName]/index.tsx
+++ b/pages/foretag/[companyName]/index.tsx
@@ -69,7 +69,7 @@ export const getServerSideProps: GetServerSideProps = async ({ params, res, loca
   const companyDataService = new CompanyDataService()
 
   const [companies, company] = await Promise.all([
-    companyDataService.getCompanies(),
+    companyDataService.getVerifiedCompanies(),
     companyDataService.getCompany(id),
   ])
 

--- a/pages/foretag/[companyName]/index.tsx
+++ b/pages/foretag/[companyName]/index.tsx
@@ -1,0 +1,87 @@
+import { GetServerSideProps } from 'next'
+import { ParsedUrlQuery } from 'querystring'
+import { serverSideTranslations } from 'next-i18next/serverSideTranslations'
+import { ReactElement } from 'react'
+import styled from 'styled-components'
+
+import { CompanyDataService } from '../../../utils/companyDataService'
+import { ONE_WEEK_MS } from '../../../utils/shared'
+import Layout from '../../../components/Layout'
+import Footer from '../../../components/Footer/Footer'
+import Company from '../../../components/Company/Company'
+import { GuessedCompany, Company as TCompany } from '../../../utils/types'
+
+const StyledLayout = styled(Layout)`
+  margin-top: 48px;
+`
+
+type Props = {
+    id: string
+  company: { verified: TCompany, guessed: GuessedCompany }
+  companyNames: string[]
+}
+
+export default function CompanyDetails({
+  id,
+  company,
+  companyNames,
+}: Props) {
+  return (
+    <Company
+      id={id}
+      company={company}
+      companyNames={companyNames}
+    />
+  )
+}
+
+CompanyDetails.getLayout = function getLayout(page: ReactElement) {
+  return (
+    <>
+      <StyledLayout>{page}</StyledLayout>
+      <Footer minimal />
+    </>
+  )
+}
+
+interface Params extends ParsedUrlQuery {
+  companyName: string
+}
+
+const cache = new Map()
+
+export const getServerSideProps: GetServerSideProps = async ({ params, res, locale }) => {
+  res.setHeader('Cache-Control', `public, stale-while-revalidate=60, max-age=${ONE_WEEK_MS}`)
+
+  // TODO: Since companies change names, we need to include a unique identifier in the company URL.
+  // For example `/foretag/astrazeneca-8a2hcte`, where the slug `8a2hcte` is the actual unique identifier.
+  // This way, we can slugify the company name in the URL, and always redirect to the correct company page
+  // even as the comapny name (and its URL) may change. This is important for maintaining stable URLs.
+  // To implement this, replace `id` by parsing the slug from the `companyName`.
+  // Maybe also rename the route parameter to `companySlug` to make it clear.
+  // NOTE: See an example implementation here:
+  // https://github.com/Greenheart/idg.tools/blob/d06c8eaaa74e780520b23f1984fd5d097bbe11c6/shared/content-utils.ts#L74-L84
+  const id = (params as Params).companyName
+  if (cache.get(id)) {
+    return cache.get(id)
+  }
+
+  const companyDataService = new CompanyDataService()
+
+  const [companies, company] = await Promise.all([
+    companyDataService.getCompanies(),
+    companyDataService.getCompany(id),
+  ])
+
+  const result = {
+    props: {
+      id,
+      company,
+      companyNames: companies.map((c) => c.Name),
+      ...await serverSideTranslations(locale as string, ['common', 'company']),
+    },
+  }
+  cache.set(id, result)
+
+  return result
+}

--- a/public/data/2024-05-31-AstraZeneca.json
+++ b/public/data/2024-05-31-AstraZeneca.json
@@ -1,0 +1,390 @@
+{
+  "companyName": "AstraZeneca",
+  "industryGics": {
+    "name": "Pharmaceuticals",
+    "sector": {
+      "code": "35",
+      "name": "Health Care"
+    },
+    "group": {
+      "code": "3520",
+      "name": "Pharmaceuticals, Biotechnology & Life Sciences"
+    },
+    "industry": {
+      "code": "352020",
+      "name": "Pharmaceuticals"
+    },
+    "subIndustry": {
+      "code": "35202010",
+      "name": "Pharmaceuticals"
+    }
+  },
+  "industryNace": {
+    "section": {
+      "code": "C",
+      "name": "Manufacturing"
+    },
+    "division": {
+      "code": "21",
+      "name": "Manufacture of basic pharmaceutical products and pharmaceutical preparations"
+    }
+  },
+  "baseYear": "2019",
+  "url": "https://www.astrazeneca.com",
+  "emissions": [
+    {
+      "year": "2019",
+      "scope1": {
+        "emissions": null,
+        "unit": "metric ton CO2e"
+      },
+      "scope2": {
+        "emissions": null,
+        "unit": "metric ton CO2e",
+        "mb": null,
+        "lb": null
+      },
+      "scope3": {
+        "emissions": 5681194,
+        "unit": "metric ton CO2e",
+        "categories": {
+          "1_purchasedGoods": 3637033,
+          "2_capitalGoods": 76941,
+          "3_fuelAndEnergyRelatedActivities": 80556,
+          "4_upstreamTransportationAndDistribution": 248112,
+          "5_wasteGeneratedInOperations": 19661,
+          "6_businessTravel": 327051,
+          "7_employeeCommuting": 46461,
+          "8_upstreamLeasedAssets": 33058,
+          "9_downstreamTransportationAndDistribution": 133627,
+          "10_processingOfSoldProducts": null,
+          "11_useOfSoldProducts": 1037501,
+          "12_endOfLifeTreatmentOfSoldProducts": 16122,
+          "13_downstreamLeasedAssets": 25072,
+          "14_franchises": null,
+          "15_investments": null,
+          "16_other": null
+        }
+      },
+      "totalEmissions": null,
+      "totalUnit": "metric ton CO2e"
+    },
+    {
+      "year": "2021",
+      "scope1": {
+        "emissions": 239468,
+        "unit": "metric ton CO2e"
+      },
+      "scope2": {
+        "emissions": 21135,
+        "unit": "metric ton CO2e",
+        "mb": 21135,
+        "lb": 189395
+      },
+      "scope3": {
+        "emissions": 5925850,
+        "unit": "metric ton CO2e",
+        "categories": {
+          "1_purchasedGoods": 4400747,
+          "2_capitalGoods": 88762,
+          "3_fuelAndEnergyRelatedActivities": 51333,
+          "4_upstreamTransportationAndDistribution": 228675,
+          "5_wasteGeneratedInOperations": 19372,
+          "6_businessTravel": 83774,
+          "7_employeeCommuting": 41293,
+          "8_upstreamLeasedAssets": 25074,
+          "9_downstreamTransportationAndDistribution": 129078,
+          "10_processingOfSoldProducts": null,
+          "11_useOfSoldProducts": 835337,
+          "12_endOfLifeTreatmentOfSoldProducts": 20023,
+          "13_downstreamLeasedAssets": 2382,
+          "14_franchises": null,
+          "15_investments": null,
+          "16_other": null
+        }
+      },
+      "totalEmissions": null,
+      "totalUnit": "metric ton CO2e"
+    },
+    {
+      "year": "2022",
+      "scope1": {
+        "emissions": 237703,
+        "unit": "metric ton CO2e"
+      },
+      "scope2": {
+        "emissions": 18491,
+        "unit": "metric ton CO2e",
+        "mb": 18491,
+        "lb": 180403
+      },
+      "scope3": {
+        "emissions": 6167415,
+        "unit": "metric ton CO2e",
+        "categories": {
+          "1_purchasedGoods": 4480479,
+          "2_capitalGoods": 76863,
+          "3_fuelAndEnergyRelatedActivities": 57975,
+          "4_upstreamTransportationAndDistribution": 218745,
+          "5_wasteGeneratedInOperations": 18434,
+          "6_businessTravel": 145814,
+          "7_employeeCommuting": 44128,
+          "8_upstreamLeasedAssets": 25872,
+          "9_downstreamTransportationAndDistribution": 118800,
+          "10_processingOfSoldProducts": null,
+          "11_useOfSoldProducts": 960650,
+          "12_endOfLifeTreatmentOfSoldProducts": 13572,
+          "13_downstreamLeasedAssets": 6082,
+          "14_franchises": null,
+          "15_investments": null,
+          "16_other": null
+        }
+      },
+      "totalEmissions": null,
+      "totalUnit": "metric ton CO2e"
+    },
+    {
+      "year": "2023",
+      "scope1": {
+        "emissions": 180898,
+        "unit": "metric ton CO2e"
+      },
+      "scope2": {
+        "emissions": 19940,
+        "unit": "metric ton CO2e",
+        "mb": 19940,
+        "lb": 183332
+      },
+      "scope3": {
+        "emissions": 6736878,
+        "unit": "metric ton CO2e",
+        "categories": {
+          "1_purchasedGoods": 4622257,
+          "2_capitalGoods": 81938,
+          "3_fuelAndEnergyRelatedActivities": 52634,
+          "4_upstreamTransportationAndDistribution": 241422,
+          "5_wasteGeneratedInOperations": 19043,
+          "6_businessTravel": 155443,
+          "7_employeeCommuting": 50827,
+          "8_upstreamLeasedAssets": 30101,
+          "9_downstreamTransportationAndDistribution": 135689,
+          "10_processingOfSoldProducts": null,
+          "11_useOfSoldProducts": 1330844,
+          "12_endOfLifeTreatmentOfSoldProducts": 14579,
+          "13_downstreamLeasedAssets": 2101,
+          "14_franchises": null,
+          "15_investments": null,
+          "16_other": null
+        }
+      },
+      "totalEmissions": null,
+      "totalUnit": "metric ton CO2e"
+    }
+  ],
+  "turnover": [
+    {
+      "year": "2019",
+      "value": null,
+      "unit": "EUR"
+    },
+    {
+      "year": "2021",
+      "value": 37136,
+      "unit": "EUR"
+    },
+    {
+      "year": "2022",
+      "value": 44359,
+      "unit": "EUR"
+    },
+    {
+      "year": "2023",
+      "value": 48551,
+      "unit": "EUR"
+    }
+  ],
+  "factors": [
+    {
+      "product": "Unknown",
+      "description": "CO2e per km driven",
+      "value": 0.13,
+      "unit": "kgCO2e/km"
+    },
+    {
+      "product": "Air2Sea&Rail",
+      "description": "Upstream transportation and distribution (% tonne.km)",
+      "value": 0.73,
+      "unit": "percentage"
+    },
+    {
+      "product": "Air2Sea&Rail",
+      "description": "Upstream transportation and distribution (% volume)",
+      "value": 0.64,
+      "unit": "percentage"
+    }
+  ],
+  "contacts": [
+    {
+      "name": "Not Provided",
+      "role": "Sustainability Manager",
+      "email": "info@astrazeneca.com",
+      "phone": "+44 (0)20 3749 5000"
+    }
+  ],
+  "goals": [
+    {
+      "description": "Reduce absolute Scope 1 and 2 greenhouse gas (GHG) emissions by 98% from 2015 base year.",
+      "year": 2026,
+      "reductionPercent": 98,
+      "baseYear": "2015"
+    },
+    {
+      "description": "100% electric road fleet where technically possible.",
+      "year": 2025,
+      "reductionPercent": 100,
+      "baseYear": "Unknown"
+    },
+    {
+      "description": "Reduce total energy consumption by 10% from 2015.",
+      "year": 2025,
+      "reductionPercent": 10,
+      "baseYear": "2015"
+    },
+    {
+      "description": "Double energy productivity from 2015.",
+      "year": 2025,
+      "reductionPercent": 100,
+      "baseYear": "2015"
+    },
+    {
+      "description": "100% renewable electricity consumption globally.",
+      "year": 2025,
+      "reductionPercent": 100,
+      "baseYear": "Unknown"
+    },
+    {
+      "description": "Reduce absolute Scope 3 GHG emissions by 50% by 2030 and 90% by 2045, from a 2019 base year.",
+      "year": 2030,
+      "reductionPercent": 50,
+      "baseYear": "2019"
+    },
+    {
+      "description": "Reduce absolute Scope 3 GHG emissions by 50% by 2030 and 90% by 2045, from a 2019 base year.",
+      "year": 2045,
+      "reductionPercent": 90,
+      "baseYear": "2019"
+    },
+    {
+      "description": "Purchase 95% of total suppliers by spend complying with Science-Based Targets (SBTs).",
+      "year": 2025,
+      "reductionPercent": 95,
+      "baseYear": "Unknown"
+    },
+    {
+      "description": "Launch a next-generation inhaler to treat asthma and COPD containing a near-zero Global Warming Potential (GWP) propellant.",
+      "year": 2025,
+      "reductionPercent": null,
+      "baseYear": "Unknown"
+    },
+    {
+      "description": "Ensure 95% of paper-based product packaging materials used are supplied from sustainable sources.",
+      "year": 2023,
+      "reductionPercent": 95,
+      "baseYear": "Unknown"
+    },
+    {
+      "description": "Ensure 100% of AstraZeneca site discharges and ≥90% of supplier site discharges are in compliance with safe API discharge concentrations.",
+      "year": 2023,
+      "reductionPercent": 100,
+      "baseYear": "Unknown"
+    },
+    {
+      "description": "Maintain 100% of active employees trained on the Code of Ethics.",
+      "year": 2025,
+      "reductionPercent": 100,
+      "baseYear": "Unknown"
+    }
+  ],
+  "initiatives": [
+    {
+      "description": "Reduce absolute Scope 1 and 2 greenhouse gas (GHG) emissions by 98% from 2015 base year.",
+      "year": 2026,
+      "reductionPercent": 98,
+      "scope": "scope1and2",
+      "comment": "The target is very ambitious."
+    },
+    {
+      "description": "100% electric road fleet where technically possible.",
+      "year": 2025,
+      "reductionPercent": 100,
+      "scope": "scope1_roadFleet",
+      "comment": "Aiming to have a fully electric road fleet by 2025."
+    },
+    {
+      "description": "Reduce total energy consumption by 10% from 2015.",
+      "year": 2025,
+      "reductionPercent": 10,
+      "scope": "totalEnergyConsumption",
+      "comment": "Reduction in total energy consumption target."
+    },
+    {
+      "description": "Double energy productivity from 2015.",
+      "year": 2025,
+      "reductionPercent": 100,
+      "scope": "energyProductivity",
+      "comment": "Aiming to double energy productivity by 2025."
+    },
+    {
+      "description": "100% renewable electricity consumption globally.",
+      "year": 2025,
+      "reductionPercent": 100,
+      "scope": "scope2_renewableElectricity",
+      "comment": "Using 100% renewable electricity globally."
+    },
+    {
+      "description": "Reduce absolute Scope 3 GHG emissions by 50% by 2030 and 90% by 2045, from a 2019 base year.",
+      "year": 2030,
+      "reductionPercent": 50,
+      "scope": "scope3",
+      "comment": "Long-term Scope 3 emissions reduction target."
+    },
+    {
+      "description": "Purchase 95% of total suppliers by spend complying with Science-Based Targets (SBTs).",
+      "year": 2025,
+      "reductionPercent": 95,
+      "scope": "scope3_1&purchasedGoodsAndServices",
+      "comment": "Science-Based Targets for suppliers."
+    },
+    {
+      "description": "Launch a next-generation inhaler to treat asthma and COPD containing a near-zero Global Warming Potential (GWP) propellant.",
+      "year": 2025,
+      "reductionPercent": null,
+      "scope": "productInnovation",
+      "comment": "Introduction of low GWP propellant inhaler."
+    },
+    {
+      "description": "Ensure 95% of paper-based product packaging materials used are supplied from sustainable sources.",
+      "year": 2023,
+      "reductionPercent": 95,
+      "scope": "productPackaging",
+      "comment": "Sustainable paper-based packaging materials."
+    },
+    {
+      "description": "Ensure 100% of AstraZeneca site discharges and ≥90% of supplier site discharges are in compliance with safe API discharge concentrations.",
+      "year": 2023,
+      "reductionPercent": 100,
+      "scope": "siteDischarges",
+      "comment": "Compliance with safe API discharge concentrations."
+    },
+    {
+      "description": "Maintain 100% of active employees trained on the Code of Ethics.",
+      "year": 2025,
+      "reductionPercent": 100,
+      "scope": "employeeTraining",
+      "comment": "Code of Ethics training for employees."
+    }
+  ],
+  "reliability": "High",
+  "needsReview": true,
+  "reviewComment": "The company has reported conflicting numbers in scope 3 compared to what could be expected and what is concluded in the totals. This needs further review."
+}

--- a/public/locales/sv/company.json
+++ b/public/locales/sv/company.json
@@ -1,0 +1,6 @@
+{
+  "otherCompanies": "Hur ser det ut för andra företag?",
+  "facts": {
+    "title": "Fakta om {{name}}"
+  }
+}

--- a/utils/companyDataService.tsx
+++ b/utils/companyDataService.tsx
@@ -1,5 +1,6 @@
 import { readFileSync } from 'fs'
 import { resolve } from 'path'
+import axios from 'axios'
 import { Company, CompanyEmissionsPerYear, GuessedCompany } from './types'
 
 function loadJSON<T>(path: string): T {
@@ -37,11 +38,15 @@ export class CompanyDataService {
     ]
   }
 
-  public getCompanies(): Array<Company> {
+  public getVerifiedCompanies(): Company[] {
     if (this.companies.length < 1) {
       throw new Error('No companies found')
     }
     return this.companies
+  }
+
+  public async getGuessedCompanies(): Promise<GuessedCompany[]> {
+    return axios.get<GuessedCompany[]>('https://api.klimatkollen.se/api/companies').then((res) => res.data)
   }
 
   public getCompany(name: string): { verified: Company, guessed: GuessedCompany } {

--- a/utils/types.ts
+++ b/utils/types.ts
@@ -147,3 +147,102 @@ export type MunicipalityTapInfo = {
   y: number
   mData: MunicipalityData
 }
+
+// TODO: Think about if/how we could unify the company data types.
+// Perhaps it makes sense to clearly separate guessed from manually verified data as long as we are using both sources.
+export type Contact = {
+  name: string;
+  role: string;
+  email: string;
+  phone: string;
+}
+
+export type Scope1 = {
+  emissions: number | null;
+  unit: string;
+}
+
+export type Scope2 = {
+  emissions: number | null;
+  unit: string;
+  mb: number | null;
+  lb: number | null;
+}
+
+export type Scope3 = {
+  emissions: number;
+  unit: string;
+  categories: { [key: string]: number | null };
+}
+
+export type GuessedEmission = {
+  year: string;
+  scope1: Scope1;
+  scope2: Scope2;
+  scope3: Scope3;
+  totalEmissions: null;
+  totalUnit: string;
+}
+
+export type Factor = {
+  product: string;
+  description: string;
+  value: number;
+  unit: string;
+}
+
+export type Goal = {
+  description: string;
+  year: number;
+  reductionPercent: number | null;
+  baseYear: string;
+}
+
+export type Group = {
+  code: string;
+  name: string;
+}
+
+export type IndustryGics = {
+  name: string;
+  sector: Group;
+  group: Group;
+  industry: Group;
+  subIndustry: Group;
+}
+
+export type IndustryNace = {
+  section: Group;
+  division: Group;
+}
+
+export type Initiative = {
+  description: string;
+  year: number;
+  reductionPercent: number | null;
+  scope: string;
+  comment: string;
+}
+
+export type Turnover = {
+  year: string;
+  value: number | null;
+  unit: string;
+}
+
+export type GuessedCompany = {
+  companyName: string;
+  industryGics: IndustryGics;
+  industryNace: IndustryNace;
+  baseYear: string;
+  url: string;
+  emissions: GuessedEmission[];
+  turnover: Turnover[];
+  factors: Factor[];
+  contacts: Contact[];
+  goals: Goal[];
+  initiatives: Initiative[];
+  reliability: string;
+  needsReview: boolean;
+  reviewComment: string;
+}


### PR DESCRIPTION
Only an example for now.

Some problems identified and documented in comments as parts of the changes so far in this branch.

Should be quite easy from this point to add more facts for various key numbers for example.

One important thing to point out is that we need to know the verified emission data for scope 1 and 2 separately, rather than `scope1n2` like it's called in the `company-data.json`. Might be worth clarifying this in the python data pipeline and update the `CompanyView` (or the company data service) to add them together.