### PR TITLE
Deploy hotfix to production

### DIFF
--- a/public/locales/sv/common.json
+++ b/public/locales/sv/common.json
@@ -27,7 +27,7 @@
   "dataMissing": "Data saknas",
   "datasets": {
     "bikes": {
-      "body": "Antal meter cykelväg per invånare per kommun år 2022. Ju längre desto bättre, god infrastruktur gynnar ökad cykling.",
+      "body": "Antal meter cykelväg per invånare per kommun år 2023. Ju längre desto bättre, god infrastruktur gynnar ökad cykling.",
       "columnHeader": "Cykelväglängd",
       "labels": ["1 m -", "1-2 m", "2-3 m", "3-4 m", "4-5 m", "5 m +"],
       "name": "Cyklarna",


### PR DESCRIPTION
Change bike land per capita year from 2022 to 2023 in dataset definitions.