### PR TITLE
fix: add sorting function for procurementDemands to fix multi-sort in `Upphandlingarna`

### DIFF
--- a/utils/createMunicipalityList.tsx
+++ b/utils/createMunicipalityList.tsx
@@ -216,6 +216,15 @@ export const municipalityColumns = (
       }
     }
 
+    if (datasetKey === 'upphandlingarna') {
+      return (rowDataA: Row<RowData>, rowDataB: Row<RowData>) => {
+        const aProcurementDemands = rowDataA.original.formattedDataPoint
+        const bProcurementDemands = rowDataB.original.formattedDataPoint
+
+        return aProcurementDemands.localeCompare(bProcurementDemands)
+      }
+    }
+
     // By default, use the standard @tanstack/table sorting functions.
     return undefined
   }


### PR DESCRIPTION
Fixes #643 

I noticed that we have a sorting function for the binary column in `Klimatplanerna` and also noticed that `Upphandlingarna` actually has no binary first-column, but rather a ternary (Ja/Nej/Kanske). The weird thing is that sorting by one column at a time works without a problem, but sorting by multiple columns does not sort the `Kommun` column.

Adding a simple sorting function for the `index`-column `Ställer krav` seems to work here. Note that I decided to go for the `formattedDataPoint`, because this sorts the string values (Ja/Nej/Kanske) instead of the `dataPoint` (2/0/1), which results in the same sorting as we currently have.

### Screenshots
<img width="480" alt="image" src="https://github.com/Klimatbyran/klimatkollen/assets/3601810/05a36177-20eb-4e91-9152-afd30f4bb162">
<img width="440" alt="image" src="https://github.com/Klimatbyran/klimatkollen/assets/3601810/f664bc2d-baa1-4f3c-90b8-fa8daab9d3e1">
<img width="444" alt="image" src="https://github.com/Klimatbyran/klimatkollen/assets/3601810/593be9ed-f582-4e94-8eac-b4fa47397187">
<img width="437" alt="image" src="https://github.com/Klimatbyran/klimatkollen/assets/3601810/a2b6647c-3687-444d-b4f5-b93b43f8f569">
