### PR TITLE
Feature/consistently slugify company urls

### DIFF
--- a/components/ComparisonTable.tsx
+++ b/components/ComparisonTable.tsx
@@ -219,11 +219,9 @@ function ComparisonTable<T extends object>({
         return
       }
 
-      const companyRoute = getCompanyURL(lowerCaseName, wikiId)
-      window.location.href = companyRoute
+      window.location.assign(getCompanyURL(lowerCaseName, wikiId))
     } else {
-      const municipalityrRoute = `/kommun/${lowerCaseName}`
-      router.push(municipalityrRoute)
+      router.push(`/kommun/${lowerCaseName}`)
     }
   }
 

--- a/components/ComparisonTable.tsx
+++ b/components/ComparisonTable.tsx
@@ -230,14 +230,12 @@ function ComparisonTable<T extends object>({
   return (
     <>
       <StyledTable key={resizeCount}>
-        {/* HACK: prevent table headers from changing size when toggling table rows. Not sure what causes the problem, but this fixes it. */}
-        {dataType === 'companies' ? (
-          <colgroup>
-            <col width="35%" />
-            <col width="30%" />
-            <col width="35%" />
-          </colgroup>
-        ) : null}
+        {/* HACK: prevent table headers from changing size when changing data view. Not sure what causes the problem, but this fixes it. */}
+        <colgroup>
+          <col width="35%" />
+          <col width="30%" />
+          <col width="35%" />
+        </colgroup>
 
         <thead>
           {table.getHeaderGroups().map((headerGroup) => (

--- a/components/ComparisonTable.tsx
+++ b/components/ComparisonTable.tsx
@@ -243,10 +243,6 @@ function ComparisonTable<T extends object>({
               {headerGroup.headers.map((header) => {
                 const currentSort = header.column.getIsSorted()
                 return (
-                // TODO: Ensure clicking table headers doesn't scroll to top.
-                // It almost seems like this could be by the table losing all its content
-                // just before re-rendering it. And since the table (or page) doesn't need as much scroll anymore,
-                // maybe it just shows the top of the table then again?
                   <TableHeader
                     key={header.id}
                     colSpan={header.colSpan}

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,7 @@
         "react-mailchimp-subscribe": "^2.1.3",
         "react-markdown": "^9.0.1",
         "rehype-external-links": "^3.0.0",
+        "slugify": "^1.6.6",
         "styled-components": "^6.1.8",
         "vite": "^5.2.11"
       },
@@ -11920,6 +11921,15 @@
       "dev": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/slugify": {
+      "version": "1.6.6",
+      "resolved": "https://registry.npmjs.org/slugify/-/slugify-1.6.6.tgz",
+      "integrity": "sha512-h+z7HKHYXj6wJU+AnS/+IH8Uh9fdcX1Lrhg1/VMdf9PwoBQXFcXiAdsy2tSK0P6gKwJLXp02r90ahUCqHk9rrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.0.0"
       }
     },
     "node_modules/snake-case": {

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "react-mailchimp-subscribe": "^2.1.3",
     "react-markdown": "^9.0.1",
     "rehype-external-links": "^3.0.0",
+    "slugify": "^1.6.6",
     "styled-components": "^6.1.8",
     "vite": "^5.2.11"
   },

--- a/utils/shared.ts
+++ b/utils/shared.ts
@@ -1,3 +1,5 @@
+import { slugifyURL } from './slugifyURL'
+
 export const normalizeString = (input: string) => input.replace('ä', 'a').replace('ö', 'o').replace('å', 'a').toLowerCase()
 
 export const toTitleCase = (str: string) => str.replace(
@@ -7,8 +9,8 @@ export const toTitleCase = (str: string) => str.replace(
 
 export const ONE_WEEK_MS = 60 * 60 * 24 * 7
 
-export const getCompanyURL = (companyName: string, wikiId: string) => {
-  const baseURL = process.env.NODE_ENV === 'production' ? 'https://beta.klimatkollen.se' : 'http://localhost:4321'
-  const dashName = companyName.toLowerCase().replaceAll(' ', '-')
-  return `${baseURL}/foretag/${dashName}-${wikiId}`
-}
+const baseURL = process.env.NODE_ENV === 'development' ? 'http://localhost:4321' : 'https://beta.klimatkollen.se'
+
+export const getCompanyURL = (companyName: string, wikiId: string) => (
+  `${baseURL}/foretag/${slugifyURL(companyName)}-${wikiId}`
+)

--- a/utils/slugifyURL.ts
+++ b/utils/slugifyURL.ts
@@ -1,0 +1,12 @@
+import slugify from 'slugify'
+
+export const slugifyURL = (url: string, locale = 'sv') => (
+  slugify(url, {
+    replacement: '-', // replace spaces with replacement character
+    remove: undefined, // remove characters that match regex
+    lower: true, // convert to lower case
+    strict: true, // strip special characters except replacement
+    locale, // locale identifier used to create locale-aware slugs
+    trim: true, // trim leading and trailing replacement chars
+  })
+)


### PR DESCRIPTION
- Consistently slugify company URLs
- Force RegionalView table to keep consistent column sizes for all datasets to improve UX