### PR TITLE
Disable automatic detection of possible phone number on mobile browsers

### DIFF
--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -9,7 +9,7 @@ export default class MyDocument extends Document {
     return (
       <Html>
         <Head>
-          <meta name="format-detection" content="telephone=no"/>
+          <meta name="format-detection" content="telephone=no" />
         </Head>
         <body>
           <Main />

--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -8,7 +8,9 @@ export default class MyDocument extends Document {
   render() {
     return (
       <Html>
-        <Head />
+        <Head>
+          <meta name="format-detection" content="telephone=no"/>
+        </Head>
         <body>
           <Main />
           <NextScript />


### PR DESCRIPTION
Fix for #673 

Reproduced this on my phone and it solved the problem. Not entirely sure if I added the code at the correct location, though.