### PR TITLE
Speed up data processing

### DIFF
--- a/data/README.md
+++ b/data/README.md
@@ -40,6 +40,13 @@ We utilize Python libraries such as Pandas and NumPy to perform various calculat
     
     If you notice any test failing, please submit a ticket about it.
 
+### Performance profiling
+
+Requires Graphwiz installed on the OS https://www.graphviz.org/download/
+```sh
+py.test tests --profile-svg && open prof/combined.svg
+```
+
 ### How to Update Data on Site
 
 To recalculate and refresh the site's data, navigate to the `/data` folder and execute the following command:

--- a/data/issues/emissions/cache_utilities.py
+++ b/data/issues/emissions/cache_utilities.py
@@ -5,7 +5,7 @@ import pyarrow.feather as feather
 import pandas as pd
 
 
-def cache_df(f: type(pd.read_excel) = None, path: str = None, freq: str = '1Y'):
+def cache_df(f: type(pd.read_excel) = None, path: str = '', freq: str = '1Y'):
     """
     Cache the DataFrame to an intermediate file and use it if created within the same period.
 
@@ -71,9 +71,6 @@ def cache_df(f: type(pd.read_excel) = None, path: str = None, freq: str = '1Y'):
 
     def caching_f(*args, **kwargs):
         input_path = kwargs.get('path') or (args[0] if args else path)
-
-        if not input_path:
-            raise ValueError("Path parameter is required either as a decorator argument or function argument.")
 
         # Create a hash of the path for the cache file
         path_hash = hashlib.md5(input_path.encode()).hexdigest()

--- a/data/issues/emissions/cache_utilities.py
+++ b/data/issues/emissions/cache_utilities.py
@@ -76,9 +76,9 @@ def cache_df(f: callable = None, path: str = None, freq: str = '1Y'):
             raise ValueError("Path parameter is required either as a decorator argument or function argument.")
 
         # Create a hash of the path for the cache file
-        excel_hash = hashlib.md5(input_path.encode()).hexdigest()
-        df_file = f'cache_df_{f.__name__}_{excel_hash}.feather'
-        columns_file = f'cache_df_{f.__name__}_{excel_hash}.pkl'
+        path_hash = hashlib.md5(input_path.encode()).hexdigest()
+        df_file = f'cache_df_{f.__name__}_{path_hash}.feather'
+        columns_file = f'cache_df_{f.__name__}_{path_hash}.pkl'
 
         # Check if cached file and columns file exist and is in the same period as now
         if os.path.exists(df_file):
@@ -95,10 +95,10 @@ def cache_df(f: callable = None, path: str = None, freq: str = '1Y'):
 
         # Process and cache the data
         df = f(*args, **kwargs)
-        # Save the original column names separately
-        original_columns = df.columns
         feather.write_feather(df, df_file)
-        pd.to_pickle(original_columns, columns_file)
+
+        # Save the original column names separately since feather does not support different heading types
+        pd.to_pickle(df.columns, columns_file)
 
         return df
 

--- a/data/issues/emissions/cache_utilities.py
+++ b/data/issues/emissions/cache_utilities.py
@@ -1,0 +1,112 @@
+import hashlib
+import os
+import pyarrow.feather as feather
+
+import pandas as pd
+
+
+def cache_df(f: callable = None, path: str = None, freq: str = '1Y'):
+    """
+    Cache the DataFrame to an intermediate file and use it if created within the same period.
+
+    Args:
+        f: A function to cache (e.g., a function that loads a DataFrame).
+        path: Path to the file to be cached. If provided, it automatically supplies the path parameter to the decorated function.
+        freq: Cache period, e.g. '1D', '1M', '1Y'. Defaults to '1Y'.
+
+    Returns:
+        A decorator that adds caching functionality to the intended function.
+
+    Example usage:
+
+    Create a test Excel file:
+        >>> df_test = pd.DataFrame({"A": [1], "B": [2]})
+        >>> test_path = "test_data.xlsx"
+        >>> df_test.to_excel(test_path, index=False)
+
+    Use the decorator to cache the DataFrame loaded from the file:
+        >>> @cache_df
+        ... def load_data(path):
+        ...     print("Creating DataFrame from file (first call)...")
+        ...     return pd.read_excel(path)
+        >>> load_data.__name__
+        'cache_df_load_data'
+        >>> print(load_data(test_path))
+        Creating DataFrame from file (first call)...
+           A  B
+        0  1  2
+
+        >>> print(load_data(test_path))  # Data loaded from cache, no print output
+           A  B
+        0  1  2
+
+    Use the decorator with a short expiration time:
+        >>> @cache_df(path=test_path, freq='1ms')
+        ... def load_data_short_expiry(path=test_path):
+        ...     print("Creating DataFrame from file (short expiration)...")
+        ...     return pd.read_excel(path)
+        >>> print(load_data_short_expiry())
+        Creating DataFrame from file (short expiration)...
+           A  B
+        0  1  2
+
+        >>> import time
+        >>> time.sleep(0.001)  # Sleep for 1 millisecond
+
+        >>> print(load_data_short_expiry())  # Data expired, loading again from file
+        Creating DataFrame from file (short expiration)...
+           A  B
+        0  1  2
+
+    Clean up the test files:
+        >>> file_hash = hashlib.md5(test_path.encode()).hexdigest()
+        >>> os.remove(test_path)
+        >>> os.remove(f"cache_df_load_data_{file_hash}.feather")
+        >>> os.remove(f"cache_df_load_data_{file_hash}.pkl")
+        >>> os.remove(f"cache_df_load_data_short_expiry_{file_hash}.feather")
+        >>> os.remove(f"cache_df_load_data_short_expiry_{file_hash}.pkl")
+    """
+    if f is None:
+        return lambda f: cache_df(f, path=path, freq=freq)
+
+    def caching_f(*args, **kwargs):
+        input_path = kwargs.get('path') or (args[0] if args else path)
+
+        if not input_path:
+            raise ValueError("Path parameter is required either as a decorator argument or function argument.")
+
+        # Create a hash of the path for the cache file
+        excel_hash = hashlib.md5(input_path.encode()).hexdigest()
+        df_file = f'cache_df_{f.__name__}_{excel_hash}.feather'
+        columns_file = f'cache_df_{f.__name__}_{excel_hash}.pkl'
+
+        # Check if cached file and columns file exist and is in the same period as now
+        if os.path.exists(df_file):
+            stat = os.stat(df_file)
+            cache_mtime = pd.Timestamp(stat.st_mtime_ns // 1_000_000, unit='ms')
+            if pd.Period(pd.Timestamp.now(), freq=freq) == pd.Period(cache_mtime, freq=freq):
+                # Load cached data
+                df = pd.read_feather(df_file)
+                # Load original column names
+                if os.path.exists(columns_file):
+                    original_columns = pd.read_pickle(columns_file)
+                    df.columns = original_columns
+                return df
+
+        # Process and cache the data
+        df = f(*args, **kwargs)
+        # Save the original column names separately
+        original_columns = df.columns
+        feather.write_feather(df, df_file)
+        pd.to_pickle(original_columns, columns_file)
+
+        return df
+
+    caching_f.__name__ = 'cache_df_' + f.__name__
+    return caching_f
+
+
+if __name__ == "__main__":
+    import doctest
+
+    doctest.testmod()

--- a/data/issues/emissions/cache_utilities.py
+++ b/data/issues/emissions/cache_utilities.py
@@ -5,17 +5,17 @@ import pyarrow.feather as feather
 import pandas as pd
 
 
-def cache_df(f: callable = None, path: str = None, freq: str = '1Y'):
+def cache_df(f: type(pd.read_excel) = None, path: str = None, freq: str = '1Y'):
     """
     Cache the DataFrame to an intermediate file and use it if created within the same period.
 
     Args:
         f: A function to cache (e.g., a function that loads a DataFrame).
-        path: Path to the file to be cached. If provided, it automatically supplies the path parameter to the decorated function.
-        freq: Cache period, e.g. '1D', '1M', '1Y'. Defaults to '1Y'.
+        path: Path to the file to be cached. If provided without f, acts as a decorator.
+        freq: Cache period, e.g. '1D', '1M', '1Y'. Defaults to '1Y'. If provided without f, acts as a decorator.
 
     Returns:
-        A decorator that adds caching functionality to the intended function.
+        Caching of the output - not calling the function unless we entered a new period.
 
     Example usage:
 

--- a/data/issues/emissions/cache_utilities.py
+++ b/data/issues/emissions/cache_utilities.py
@@ -5,7 +5,7 @@ import pyarrow.feather as feather
 import pandas as pd
 
 
-def cache_df(f: type(pd.read_excel) = None, path: str = '', freq: str = '1Y'):
+def cache_df(f: type(pd.read_excel) = None, path: str = '', freq: str = '1Y') -> type(pd.read_excel):
     """
     Cache the DataFrame to an intermediate file and use it if created within the same period.
 

--- a/data/issues/emissions/historical_data_calculations.py
+++ b/data/issues/emissions/historical_data_calculations.py
@@ -12,7 +12,7 @@ def get_smhi_data():
         pandas.DataFrame: The dataframe containing the SMHI data.
     """
 
-    df_raw = pd.read_excel(PATH_SMHI)
+    df_raw = pd.read_excel(PATH_SMHI, engine="calamine")
 
     # Remove the first 4 rows and reset the index
     df_raw = df_raw.drop([0, 1, 2]).reset_index(drop=True)

--- a/data/issues/emissions/historical_data_calculations.py
+++ b/data/issues/emissions/historical_data_calculations.py
@@ -15,7 +15,7 @@ def get_smhi_data(path=PATH_SMHI):
         pandas.DataFrame: The dataframe containing the SMHI data.
     """
 
-    df_raw = pd.read_excel(PATH_SMHI)
+    df_raw = pd.read_excel(path, engine="openpyxl")
 
     # Remove the first 4 rows and reset the index
     df_raw = df_raw.drop([0, 1, 2]).reset_index(drop=True)

--- a/data/issues/emissions/historical_data_calculations.py
+++ b/data/issues/emissions/historical_data_calculations.py
@@ -1,112 +1,9 @@
-import hashlib
-import os
-
 import pandas as pd
-import pyarrow.feather as feather
+
+from cache_utilities import cache_df
 
 PATH_SMHI = 'https://nationellaemissionsdatabasen.smhi.se/' + \
     'api/getexcelfile/?county=0&municipality=0&sub=CO2'
-
-
-def cache_df(f: callable = None, path: str = None, freq: str = '1Y'):
-    """
-    Cache the DataFrame to an intermediate file and use it if created within the same period.
-
-    Args:
-        f: A function to cache (e.g., a function that loads a DataFrame).
-        path: Path to the file to be cached. If provided, it automatically supplies the path parameter to the decorated function.
-        freq: Cache period, e.g. '1D', '1M', '1Y'. Defaults to '1Y'.
-
-    Returns:
-        A decorator that adds caching functionality to the intended function.
-
-    Example usage:
-
-    Create a test Excel file:
-        >>> df_test = pd.DataFrame({"A": [1], "B": [2]})
-        >>> test_path = "test_data.xlsx"
-        >>> df_test.to_excel(test_path, index=False)
-
-    Use the decorator to cache the DataFrame loaded from the file:
-        >>> @cache_df
-        ... def load_data(path):
-        ...     print("Creating DataFrame from file (first call)...")
-        ...     return pd.read_excel(path)
-        >>> load_data.__name__
-        'cache_df_load_data'
-        >>> print(load_data(test_path))
-        Creating DataFrame from file (first call)...
-           A  B
-        0  1  2
-
-        >>> print(load_data(test_path))  # Data loaded from cache, no print output
-           A  B
-        0  1  2
-
-    Use the decorator with a short expiration time:
-        >>> @cache_df(path=test_path, freq='1ms')
-        ... def load_data_short_expiry(path=test_path):
-        ...     print("Creating DataFrame from file (short expiration)...")
-        ...     return pd.read_excel(path)
-        >>> print(load_data_short_expiry())
-        Creating DataFrame from file (short expiration)...
-           A  B
-        0  1  2
-
-        >>> import time
-        >>> time.sleep(0.001)  # Sleep for 1 millisecond
-
-        >>> print(load_data_short_expiry())  # Data expired, loading again from file
-        Creating DataFrame from file (short expiration)...
-           A  B
-        0  1  2
-
-    Clean up the test files:
-        >>> file_hash = hashlib.md5(test_path.encode()).hexdigest()
-        >>> os.remove(test_path)
-        >>> os.remove(f"cache_df_load_data_{file_hash}.feather")
-        >>> os.remove(f"cache_df_load_data_{file_hash}.pkl")
-        >>> os.remove(f"cache_df_load_data_short_expiry_{file_hash}.feather")
-        >>> os.remove(f"cache_df_load_data_short_expiry_{file_hash}.pkl")
-    """
-    if f is None:
-        return lambda f: cache_df(f, path=path, freq=freq)
-
-    def caching_f(*args, **kwargs):
-        input_path = kwargs.get('path') or (args[0] if args else path)
-
-        if not input_path:
-            raise ValueError("Path parameter is required either as a decorator argument or function argument.")
-
-        # Create a hash of the path for the cache file
-        url_hash = hashlib.md5(input_path.encode()).hexdigest()
-        cache_file = f'cache_df_{f.__name__}_{url_hash}.feather'
-        columns_file = f'cache_df_{f.__name__}_{url_hash}.pkl'
-
-        # Check if cached file and columns file exist and their timestamps
-        if os.path.exists(cache_file):
-            stat = os.stat(cache_file)
-            cache_mtime = pd.Timestamp(stat.st_mtime_ns // 1_000_000, unit='ms')
-            if pd.Period(pd.Timestamp.now(), freq=freq) == pd.Period(cache_mtime, freq=freq):
-                # Load cached data
-                df = pd.read_feather(cache_file)
-                # Load original column names
-                if os.path.exists(columns_file):
-                    original_columns = pd.read_pickle(columns_file)
-                    df.columns = original_columns
-                return df
-
-        # Process and cache the data
-        df = f(*args, **kwargs)
-        # Save the original column names separately
-        original_columns = df.columns
-        feather.write_feather(df, cache_file)
-        pd.to_pickle(original_columns, columns_file)
-
-        return df
-
-    caching_f.__name__ = 'cache_df_' + f.__name__
-    return caching_f
 
 
 @cache_df(path=PATH_SMHI)
@@ -214,9 +111,3 @@ def get_n_prep_data_from_smhi(df):
     # df_merge = df_total.merge(df_sectors, on='Kommun', how='left')
 
     return df
-
-
-if __name__ == "__main__":
-    import doctest
-
-    doctest.testmod()

--- a/data/issues/emissions/historical_data_calculations.py
+++ b/data/issues/emissions/historical_data_calculations.py
@@ -15,7 +15,7 @@ def get_smhi_data(path=PATH_SMHI):
         pandas.DataFrame: The dataframe containing the SMHI data.
     """
 
-    df_raw = pd.read_excel(path, engine="calamine")
+    df_raw = pd.read_excel(PATH_SMHI)
 
     # Remove the first 4 rows and reset the index
     df_raw = df_raw.drop([0, 1, 2]).reset_index(drop=True)

--- a/data/issues/emissions/historical_data_calculations.py
+++ b/data/issues/emissions/historical_data_calculations.py
@@ -1,6 +1,6 @@
 import pandas as pd
 
-from cache_utilities import cache_df
+from .cache_utilities import cache_df
 
 PATH_SMHI = 'https://nationellaemissionsdatabasen.smhi.se/' + \
     'api/getexcelfile/?county=0&municipality=0&sub=CO2'

--- a/data/pyproject.toml
+++ b/data/pyproject.toml
@@ -1,0 +1,6 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "klimatkollen-data"

--- a/data/requirements.txt
+++ b/data/requirements.txt
@@ -5,3 +5,5 @@ openpyxl
 pyarrow
 scipy
 pytest
+pytest-profiling
+graphviz

--- a/data/requirements.txt
+++ b/data/requirements.txt
@@ -8,3 +8,4 @@ pytest
 pytest-profiling
 graphviz
 python-calamine
+feather-format

--- a/data/requirements.txt
+++ b/data/requirements.txt
@@ -7,3 +7,4 @@ scipy
 pytest
 pytest-profiling
 graphviz
+python-calamine

--- a/data/requirements.txt
+++ b/data/requirements.txt
@@ -8,4 +8,3 @@ pytest
 pytest-profiling
 graphviz
 python-calamine
-feather-format

--- a/data/requirements.txt
+++ b/data/requirements.txt
@@ -7,4 +7,3 @@ scipy
 pytest
 pytest-profiling
 graphviz
-python-calamine


### PR DESCRIPTION
Closes #682 by adding a test profiling tool, a faster excel parser and a DataFrame caching decorator. Reduces test suite execution time from 15 seconds to 8 seconds on first run and 0.3 seconds on second run when tested on a Mac Air M1.