### PR TITLE
Production deployment: fetch company data fram api (#704)

### DIFF
--- a/utils/createCompanyList.tsx
+++ b/utils/createCompanyList.tsx
@@ -28,10 +28,10 @@ const getCustomSortFn = ({
   sortAscending = false,
   scope = 'Scope1n2',
 }: {
-  stringsOnTop?: boolean,
-  sortAscending?: boolean,
-  scope?: keyof Company['Emissions'],
-} = {}) => (rowA: Row<Company>, rowB: Row<Company>) => {
+    stringsOnTop?: boolean
+    sortAscending?: boolean
+    scope?: keyof Company['Emissions']
+  } = {}) => (rowA: Row<Company>, rowB: Row<Company>) => {
   const a = rowA.original.Emissions[scope]
   const b = rowB.original.Emissions[scope]
 
@@ -43,7 +43,7 @@ const getCustomSortFn = ({
   }
   if (aIsNaN || bIsNaN) {
     // eslint-disable-next-line no-nested-ternary
-    return stringsOnTop ? (aIsNaN ? -1 : 1) : (aIsNaN ? 1 : -1)
+    return stringsOnTop ? (aIsNaN ? -1 : 1) : aIsNaN ? 1 : -1
   }
 
   // Sort non-NaN values normally
@@ -58,8 +58,14 @@ export const companyColumns = (t: TFunction): ColumnDef<Company>[] => {
     {
       header: t('common:company'),
       cell: (row) => (row.cell.row.original.WikiId ? (
-        <Link href={getCompanyURL(row.cell.row.original.Name, row.cell.row.original.WikiId)}>{row.cell.row.original.Name}</Link>
-      ) : row.cell.row.original.Name),
+        <Link
+          href={getCompanyURL(row.cell.row.original.Name, row.cell.row.original.WikiId)}
+        >
+          {row.cell.row.original.Name}
+        </Link>
+      ) : (
+        row.cell.row.original.Name
+      )),
       accessorKey: 'Name',
     },
     {
@@ -68,14 +74,14 @@ export const companyColumns = (t: TFunction): ColumnDef<Company>[] => {
         const scope1n2Emissions = row.cell.row.original.Emissions.Scope1n2
         const hasValue = Number.isFinite(scope1n2Emissions)
 
-        // console.log({ row, Emissions: row.cell.row.original.Emissions })
-        // NOTE: The type does not match the actual values here.
-        // TS thinks scope1n2Emissions has the type `CompanyScope`, but according to the logging above,
-        // it is in fact just a number or null.
-        // TODO: Fix this when we get data from the API
-        const scope1n2String = hasValue ? formatter.format(scope1n2Emissions as unknown as number) : notReported
+        const scope1n2String = hasValue
+          ? formatter.format(scope1n2Emissions as unknown as number)
+          : notReported
         return (
-          <ScopeColumn isMissing={scope1n2String === notReported} className={hasValue ? 'font-mono' : ''}>
+          <ScopeColumn
+            isMissing={scope1n2String === notReported}
+            className={hasValue ? 'font-mono' : ''}
+          >
             {scope1n2String}
           </ScopeColumn>
         )
@@ -89,14 +95,14 @@ export const companyColumns = (t: TFunction): ColumnDef<Company>[] => {
         const scope3Emissions = row.cell.row.original.Emissions.Scope3
         const hasValue = Number.isFinite(scope3Emissions)
 
-        // console.log({ row, Emissions: row.cell.row.original.Emissions })
-        // NOTE: The type does not match the actual values here.
-        // TS thinks scope3Emissions has the type `CompanyScope`, but according to the logging above,
-        // it is in fact just a number or null.
-        // TODO: Fix this when we get data from the API
-        const scope3String = hasValue ? formatter.format(scope3Emissions as unknown as number) : notReported
+        const scope3String = hasValue
+          ? formatter.format(scope3Emissions as unknown as number)
+          : notReported
         return (
-          <ScopeColumn isMissing={scope3String === notReported} className={hasValue ? 'font-mono' : ''}>
+          <ScopeColumn
+            isMissing={scope3String === notReported}
+            className={hasValue ? 'font-mono' : ''}
+          >
             {scope3String}
           </ScopeColumn>
         )

--- a/utils/types.ts
+++ b/utils/types.ts
@@ -10,20 +10,55 @@ export type Image = {
 
 // Companies
 
-export type CompanyScope = {
-  Emissions: string
-  Unit: string
-  BaseYear: string
-  [key: string]: unknown
+export type Metadata = {
+  verifiedBy: {
+    name: string
+  } | null,
 }
 
+export type CompanyJsonData = {
+  name: string
+  tags: Array<string>
+  description?: string
+  wikidataId?: string
+  reportingPeriods: Array<{
+    emissions?: {
+      scope1?: {
+        total?: number
+        metadata: Metadata
+      }
+      scope2?: {
+        mb?: number
+        metadata: Metadata
+        calculatedTotalEmissions: number
+      }
+      scope3?: {
+        statedTotalEmissions?: {
+          total?: number
+          metadata: Metadata
+        }
+        calculatedTotalEmissions: number
+      }
+      scope1And2: {
+        total?: number
+        metadata: Metadata
+      }
+      calculatedTotalEmissions: number
+    }
+    reportURL?: string
+  }>
+}
+
+export type CompaniesJsonData = Array<CompanyJsonData>
+
 export type CompanyEmissionsPerYear = {
-  Scope1n2: CompanyScope
-  Scope3: CompanyScope
+  Scope1n2: number | null
+  Scope3: number | null
 }
 
 export type Company = {
   Name: string
+  Tags: string[]
   Url: string
   WikiId: string | null
   Comment: string
@@ -87,14 +122,14 @@ export type Municipality = {
   HitNetZero: number | string
   BudgetRunsOut: string
   ElectricCars: number
-  ElectricCarChangePercent: number,
-  ElectricCarChangeYearly: Array<number>,
-  ClimatePlan: ClimatePlan,
-  BicycleMetrePerCapita: number,
-  TotalConsumptionEmission: number,
-  ElectricVehiclePerChargePoints: number,
-  ProcurementScore: number,
-  ProcurementLink: string,
+  ElectricCarChangePercent: number
+  ElectricCarChangeYearly: Array<number>
+  ClimatePlan: ClimatePlan
+  BicycleMetrePerCapita: number
+  TotalConsumptionEmission: number
+  ElectricVehiclePerChargePoints: number
+  ProcurementScore: number
+  ProcurementLink: string
 }
 
 export type DataDescriptionDataPoints = {
@@ -120,7 +155,7 @@ export type DataDescription = {
   stringsOnTop?: boolean // If true, the strings will be sorted to the top of the table
 }
 
-export type DatasetKey = typeof validDatasets[number]
+export type DatasetKey = (typeof validDatasets)[number]
 export type DataDescriptions = Record<DatasetKey, DataDescription>
 
 export type CurrentDataPoints = {


### PR DESCRIPTION
* fetch company data fram api

* run lint

* change from scope2 lb to mb

* minor cleanup

* fix type error and linting

* add support for 0 and undefined scope values

* fix ts error

* fix error in graph component

* remove unrelated files

* add support for tags

* support edge cases with combined scope 1 n 2 emissions

* correct operator

* Use native `fetch()` which is stable since Node.js 21.0 (We're using 22 in prod)

* Update logic for selecting different values

* Improve error

* Allow preview for mid-cap companies

* Reduce data sent to client

---------